### PR TITLE
Add claudecoach: iRacing telemetry coaching tool + skill

### DIFF
--- a/.claude/skills/claudecoach/SKILL.md
+++ b/.claude/skills/claudecoach/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: claudecoach
+description: >-
+  Coach an iRacing driving session from raw telemetry. Parses .ibt files, compares
+  the driver's best lap against a fast reference, finds where time and consistency
+  are lost, and tracks improvement across sessions via a journal — run through a
+  blind-test protocol so the analysis and the driver's own read don't bias each
+  other. Use when the user wants to review a lap or stint, find where they're slow
+  or inconsistent, check if they're improving, or "look at my telemetry".
+---
+
+# claudecoach — iRacing telemetry coaching
+
+A local Go tool (`cmd/ibt`) decodes iRacing `.ibt` telemetry into driving metrics;
+you (Claude) interpret them. The tool tabulates — you coach. Run everything from the
+repo root with `go run ./cmd/ibt <command> ...` (no build step needed).
+
+## Where the files are
+
+- **Driver sessions:** `/mnt/c/Users/JonSa/Documents/iRacing/telemetry/` — newest first
+  with `ls -t`. Filenames encode car, track, and timestamp. (This is a WSL box;
+  `~/Documents` and `~/Downloads` do **not** resolve — use the `/mnt/c/...` paths.)
+- **Reference laps (a fast pro):** `/mnt/c/Users/JonSa/Downloads/26S3 SF23 <Track> Telemetry Replay Lapfiles/telemetry race.ibt`
+  (also `telemetry quali.ibt`). Match the track to the driver's session.
+- **Journal (trends):** `claudecoach/journal/<track>/sessions.jsonl` — gitignored, local.
+- **Writeups:** `telemetry-notes/<track>-analysis.md` (also gitignored).
+
+## The commands
+
+```
+go run ./cmd/ibt summary      "<file.ibt>"                          # lap table, best flying lap, car/track/driver, CONDITIONS
+go run ./cmd/ibt channels     "<file.ibt>"                          # list telemetry channels
+go run ./cmd/ibt consistency  "<file.ibt>"                          # per-corner consistency, sector variance (single file)
+go run ./cmd/ibt compare      "<you>" <lap> "<ref>" <lap> [csv]     # position-aligned delta, segment gain/loss, style, rotation check
+go run ./cmd/ibt brake        "<you>" <lap> "<ref>" <lap>           # brake modulation per corner (sat/fine/jerk)
+go run ./cmd/ibt section      "<you>" <lap> "<ref>" <lap> <loM> <hiM># deep-dive a window (throttle, steering, gear, line, exit)
+go run ./cmd/ibt journal add    "<file.ibt>"                        # append this session's summary to the journal
+go run ./cmd/ibt journal trends "<file.ibt | track-name>"          # cross-session trends
+```
+
+`compare` takes **any two files** — it does not have to be you-vs-reference. Comparing
+your own two sessions (e.g. before/after a setup or hardware change) is often the single
+most valuable run: it isolates one variable. Use it that way deliberately.
+
+Corners are auto-detected from speed minima on the fastest lap, named `C1..Cn@dist`. They
+are **lap-dependent** (a tire-saving lift or a flat-out kink leaves no dip), so the same
+corner can shift number between sessions — always refer to a corner by its **distance**
+(`C3@1528m`), never its bare number, when writing anything cross-session. The journal
+matches corners across sessions by apex distance for this reason.
+
+## Workflow
+
+1. **Locate.** Find the driver's session (usually the newest, or the one they name) and a
+   matching reference for that track.
+2. **Establish comparability — BEFORE comparing anything.** Run `summary` on both files and
+   read the **conditions block** (fuel, session type, track temp, brake bias). A lap time
+   only means something against another lap at the *same* fuel load, session type, and
+   roughly the same temps. An 8 L quali lap vs a 55 L race lap is not a valid A/B and will
+   invert your conclusion. If the driver's "best lap" was set in a non-comparable session,
+   the right reference is a comparable one — often their own earlier lap, not the pro's.
+   **Also just ask the driver:** what changed (hardware, setup, aids, tires), and what the
+   conditions were. This context-gathering is *not* part of the blind test (see step 4).
+3. **Run the analysis and form your read — but hold it.** `consistency` on the driver's
+   session; `compare` (comparable driver lap vs reference). Study the corner table, segment
+   gains/losses, driving-style split, and the **rotation check**. Deep-dive suspect corners
+   with `brake` and `section` (watch steering lock and gear, not just speed/throttle).
+4. **BLIND TEST (do not skip).** Before you reveal anything:
+   - Write your full read to a scratch file (a locked diagnosis).
+   - Ask the driver what *they* think their main issues are — their gut, unprompted by your
+     findings. **Only your findings are sealed; gathering context is not.** Fuel, hardware,
+     conditions, aids, "which corner felt bad" — ask freely; those make the analysis correct.
+   - Then reveal, and **score their read against the data** (right / partly / inverted),
+     calling out agreements and surprises. This is the core of the exercise.
+5. **When the driver pushes back on a finding, treat it as a lead, not resistance.** A driver
+   saying "the car won't do that" or "if I pin it I'm in the wall" is *data* — usually the
+   best error-correction signal you have. Their physical intuition often exposes that your
+   finding was a symptom, not a cause (e.g. "get to full throttle" was shallow; the real
+   issue was carrying too much steering lock — the car wasn't rotated). Re-probe with the
+   tool before defending your read. "Keep the driver's dignity" means *don't lecture* — it
+   does **not** mean don't argue back.
+6. **Trend check.** Run `journal trends` for the track. If the journal is empty or sparse
+   for this track, first offer to `journal add` the comparable prior sessions (same fuel /
+   session type) so the trend is real — then read it. Frame repeat-track findings as
+   "better / same / worse than last time."
+7. **Journal it.** `journal add` the session (safe to re-run — it dedupes by filename).
+8. **Writeup (offer).** Update `telemetry-notes/<track>-analysis.md` with a dated section:
+   the blind-test scorecard, key deltas, and a short "practice priorities" list.
+
+## Reading the output (what the metrics mean)
+
+- **summary conditions** — fuel / session type / temps / brake bias. Comparability gate;
+  read first.
+- **consistency** — `min-speed STDDEV` = apex-speed spread lap-to-lap. `brakeSTD(m)` =
+  braking-*point* spread; `n/a` means no braking there, or the onset fell outside the search
+  window (it is *not* "perfectly consistent" — never report `n/a` as a win). The
+  slowest-corner brake-saturation block shows whether the driver mashes to 100%.
+- **compare** — segment `LOSS/gain` = where lap time goes. Driving-style %. The **rotation
+  check**: at points where the ref is flat and the driver isn't, if the driver carries more
+  steering lock the car isn't rotated — the throttle gap is a *symptom*; coach "unwind the
+  lock sooner," never "just be flat" (that's how you crash on a light rear over a kerb).
+- **brake** — `sat%` = share pinned >95% (mashing). `fine%` = share in the 15–85% band.
+  `jerk` = steppiness. Low sat% + high fine% = clean, modulated braking.
+- **section** — steering `|lock|` (deg), `gear` at each sub-apex (nearest-sampled, discrete),
+  `line wander` = lap-to-lap GPS spread, `throttle-resume` = exit-commitment distance
+  (earlier = better). A driver can be limited by rotation *or* running a shorter gear than
+  the reference through an exit — both make "be flatter" wrong advice.
+
+## Interpreting, not just reporting
+
+Numbers are the input to coaching, not the output. Tie findings to mechanism (brake feel,
+throttle commitment, rotation, line, gearing, tire management) and to what changed (hardware,
+setup, conditions). A single number is a symptom — chase the cause before you prescribe.
+
+## Gotchas
+
+- **Comparability first.** The most common way to be confidently wrong is comparing across
+  fuel loads or session types. Always read the conditions block.
+- **Corners by distance, not number** (`C3@1528m`). Bare `C1..Cn` shift between sessions.
+- **Ad-hoc probes:** to answer a question no command covers, you can write a throwaway Go
+  program against the `analysis` package. `go run <dir>/` fails ("directory outside main
+  module") — list the `.go` files explicitly, or add it under `cmd/`. Use `analysis.Nearest`
+  (not `Interp`) for discrete channels like gear.
+
+## Worked example — the loop this exists to close
+
+Suzuka round 1 flagged the driver mashing 100% brake on every lap and concluded stiffer
+brake hardware was justified. He changed his pedal elastomers; at Mugello he now runs 0%
+brake saturation, never exceeding ~0.87. A prior round's prescription → a hardware change →
+measurable confirmation a round later is exactly what the journal is for. Look for these
+loops and name them.

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,17 @@
 .idea
 .terraform/
-.claude/
+# .claude — ignore everything except the checked-in claudecoach skill
+.claude/*
+!.claude/skills/
+.claude/skills/*
+!.claude/skills/claudecoach/
 
 dist/
 
 aws_account_prep/terraform.tfvars
 
 PLAN*
+
+# personal telemetry journal — local only, not versioned
+claudecoach/journal/
+telemetry-notes/

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,15 @@ dist/raceIngestionProcessorLambda.zip: dist $(GO_FILES)
 .PHONY: build
 build: dist/apiLambda.zip dist/websocketLambda.zip dist/raceIngestionProcessorLambda.zip ## Build all Lambda deployment packages
 
+##@ Telemetry Coach
+
+dist/ibt: dist $(GO_FILES)
+	go build -o dist/ibt ./cmd/ibt
+	@echo "built dist/ibt — see claudecoach/README.md"
+
+.PHONY: ibt
+ibt: dist/ibt ## Build the iRacing telemetry coaching CLI (cmd/ibt)
+
 frontend/dist: $(FRONTEND_FILES) frontend/package.json frontend/package-lock.json frontend/index.html
 	cd frontend && npm ci && VITE_API_BASE_URL=$$(terraform -chdir=../terraform output -raw api_url) VITE_WS_BASE_URL=$$(terraform -chdir=../terraform output -raw ws_url) npm run build
 

--- a/README.md
+++ b/README.md
@@ -66,13 +66,16 @@ flowchart TB
 │   ├── lambda-based-api/   # AWS Lambda handler (REST API)
 │   ├── race-ingestion-processor/ # SQS consumer for race data ingestion
 │   ├── standalone-api/     # Local development server
-│   └── websocket-lambda/   # WebSocket Lambda handler
+│   ├── websocket-lambda/   # WebSocket Lambda handler
+│   └── ibt/                # iRacing telemetry coaching CLI (local tool, not deployed)
 ├── correlation/            # Request correlation ID middleware
 ├── ingestion/              # Race data ingestion processing
 ├── iracing/                # iRacing API client and OAuth integration
 ├── store/                  # Data persistence layer (DynamoDB)
+├── telemetry/              # .ibt decoder + analysis core (used by cmd/ibt; reusable)
 ├── tracks/                 # Track data service (merges iRacing track info + assets)
 ├── ws/                     # WebSocket handler package
+├── claudecoach/            # Telemetry coaching: journal + docs (see claudecoach/README.md)
 ├── frontend/               # Vue 3 SPA
 ├── terraform/              # Infrastructure as Code
 ├── website/                # Static marketing site
@@ -228,6 +231,41 @@ A single-page application built with Vue 3, TypeScript, and Vite.
 | [`frontend/src/App.vue`](frontend/src/App.vue) | Root component |
 | [`frontend/src/router/index.ts`](frontend/src/router/index.ts) | Vue Router configuration |
 | [`frontend/src/views/HomeView.vue`](frontend/src/views/HomeView.vue) | Home page |
+
+## Telemetry Coaching (claudecoach)
+
+A local driving-analysis system, separate from the deployed app: a Go CLI decodes
+iRacing `.ibt` telemetry into driving metrics, and Claude — via the **`claudecoach`
+skill** ([`.claude/skills/claudecoach/SKILL.md`](.claude/skills/claudecoach/SKILL.md)) —
+interprets them through a blind-test coaching protocol, tracking improvement across
+sessions in a journal. Built in the main Go module (`cmd/ibt` + `telemetry/`) with an eye
+toward a future "upload telemetry → coaching" app feature. Full docs:
+[`claudecoach/README.md`](claudecoach/README.md).
+
+### Using the skill
+
+Ask Claude Code to review a session — e.g. *"look at my latest Mugello telemetry"* or
+*"am I improving at Suzuka?"* — and the `claudecoach` skill drives the workflow: locate
+the session and a fast reference lap, run the analysis, **hold its read while you state
+yours** (the blind test), then reveal and score, journal the session, and update trends.
+
+### Using the CLI directly
+
+```bash
+make ibt                       # build dist/ibt
+go run ./cmd/ibt summary      "<file.ibt>"                         # lap table + best flying lap
+go run ./cmd/ibt consistency  "<file.ibt>"                         # per-corner consistency, sector variance
+go run ./cmd/ibt compare      "<you>" <lap> "<ref>" <lap>          # position-aligned delta vs a reference
+go run ./cmd/ibt brake        "<you>" <lap> "<ref>" <lap>          # brake modulation per corner
+go run ./cmd/ibt section      "<you>" <lap> "<ref>" <lap> <lo> <hi># deep-dive a distance window
+go run ./cmd/ibt journal add    "<file.ibt>"                       # append a session summary
+go run ./cmd/ibt journal trends "<file.ibt | track>"              # cross-session trends
+```
+
+Corners, the flying-lap window, and sector splits are all derived from the data, so the
+tool works on any track/car. The journal lives in `claudecoach/journal/` (gitignored,
+local). See [`claudecoach/README.md`](claudecoach/README.md) for the full command
+reference and design notes.
 
 ## Infrastructure (Terraform)
 

--- a/claudecoach/README.md
+++ b/claudecoach/README.md
@@ -1,0 +1,64 @@
+# claudecoach — iRacing telemetry coaching
+
+A personal driving-analysis system: a Go CLI decodes iRacing `.ibt` telemetry into
+driving metrics, and Claude (via the `claudecoach` skill) interprets them through a
+blind-test coaching protocol, tracking improvement across sessions in a journal.
+
+Not part of the deployed racelog app — but built in the main Go module (`cmd/ibt` +
+`telemetry/`) with an eye toward a future "upload telemetry → coaching" feature, so the
+analysis lives in reusable, tested packages.
+
+## Layout
+
+| Path | What |
+|---|---|
+| `telemetry/ibt/` | `.ibt` binary decoder (dependency-free, read-only) |
+| `telemetry/analysis/` | pure analysis: resampling, flying-lap filter, corner detection, session summaries — the reusable core, with tests |
+| `cmd/ibt/` | the CLI (thin formatting over `telemetry/analysis`) |
+| `claudecoach/journal/` | per-track session summaries (`sessions.jsonl`) — **gitignored, local** |
+| `.claude/skills/claudecoach/SKILL.md` | the coaching workflow Claude follows |
+| `telemetry-notes/` | narrative writeups (e.g. `suzuka-sf23-analysis.md`) |
+
+## Build & run
+
+```bash
+make ibt                       # builds dist/ibt
+# or just run directly from the repo root:
+go run ./cmd/ibt <command> ...
+go test ./telemetry/...        # unit tests for the analysis core
+```
+
+## Commands
+
+```
+summary      <file.ibt>                              lap table, best flying lap, car/track/driver
+channels     <file.ibt>                              list telemetry channels
+consistency  <file.ibt> [prom] [spacing] [maxApex] [smoothWin] [gridN]
+                                                     per-corner consistency + sector variance (single file)
+compare      <you.ibt> <lap> <ref.ibt> <lap> [csv]   position-aligned delta, segment gain/loss, driving style
+brake        <you.ibt> <lap> <ref.ibt> <lap>         brake modulation per detected corner (sat/fine/jerk)
+section      <you.ibt> <lap> <ref.ibt> <lap> <loM> <hiM>
+                                                     deep-dive a distance window (throttle, GPS line, exit)
+journal add    <session.ibt>                         append this session's summary (dedupes by filename)
+journal trends <session.ibt | track-name>            cross-session trends
+```
+
+The optional `consistency` args are corner-detection tuning knobs; defaults suit a
+high-downforce open-wheeler. Corners are auto-detected from speed minima on the fastest
+lap and named `C1..Cn`.
+
+## Design notes
+
+- **Track-agnostic.** Corner apexes, the flying-lap window (relative to the session best),
+  and sector splits are all derived from the data — no per-track constants. Tested on
+  Suzuka (~1:37) and Mugello (~1:27).
+- **Corner detection is lap-dependent.** A corner taken flat or with only a tire-saving
+  lift leaves no speed minimum, so it won't be detected. A per-track *overlay* (canonical
+  named corner list, stable across sessions) is planned to fix this for trend-tracking;
+  see the stub in `telemetry/analysis/overlays.go`.
+- **The tool tabulates; Claude coaches.** Interpretation is deliberately not baked in.
+
+## Source data (not committed)
+
+- Driver sessions: `~/Documents/iRacing/telemetry/superformulasf23 *_<track> *.ibt`
+- Reference laps: `~/Downloads/26S3 SF23 <Track> Telemetry Replay Lapfiles/telemetry {race,quali}.ibt`

--- a/cmd/ibt/brakestats.go
+++ b/cmd/ibt/brakestats.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/jonsabados/saturdaysspinout/telemetry/analysis"
+	"github.com/jonsabados/saturdaysspinout/telemetry/ibt"
+)
+
+type brakeZoneStat struct {
+	name            string
+	secsOnBrake     float64
+	meanBrake       float64
+	peakBrake       float64
+	reversals       int
+	reversalsPerSec float64
+	rmsRate         float64 // RMS of per-sample brake delta (smoothness; higher=jerkier)
+	satFrac         float64 // fraction of on-brake time pinned >95% (saturation)
+	fineFrac        float64 // fraction of on-brake time in fine mid-range 15-85%
+	riseTime        float64 // seconds from brake-on to first reaching 95% (0 if never)
+}
+
+// analyze brake modulation for lap d within [lo,hi] meters
+func brakeZone(d analysis.Lap, dt float64, lo, hi float64) brakeZoneStat {
+	var s brakeZoneStat
+	const onThresh = 0.05
+	const noise = 0.02 // ignore brake wiggle smaller than this for reversal counting
+	var sumB, sumRate2 float64
+	nOn, nSat, nFine := 0, 0, 0
+	prevDelta := 0.0
+	haveDelta := false
+	for i := 1; i < len(d.Dist); i++ {
+		if d.Dist[i] < lo || d.Dist[i] > hi {
+			continue
+		}
+		b := d.Brk[i]
+		if b > onThresh {
+			nOn++
+			sumB += b
+			if b > s.peakBrake {
+				s.peakBrake = b
+			}
+			if b > 0.95 {
+				nSat++
+			}
+			if b >= 0.15 && b <= 0.85 {
+				nFine++
+			}
+			delta := d.Brk[i] - d.Brk[i-1]
+			sumRate2 += delta * delta
+			if math.Abs(delta) > noise {
+				if haveDelta && signf(delta) != signf(prevDelta) {
+					s.reversals++
+				}
+				prevDelta = delta
+				haveDelta = true
+			}
+		}
+	}
+	s.secsOnBrake = float64(nOn) * dt
+	if nOn > 0 {
+		s.meanBrake = sumB / float64(nOn)
+		s.rmsRate = math.Sqrt(sumRate2/float64(nOn)) / dt // brake units per second
+		s.satFrac = float64(nSat) / float64(nOn)
+		s.fineFrac = float64(nFine) / float64(nOn)
+	}
+	if s.secsOnBrake > 0 {
+		s.reversalsPerSec = float64(s.reversals) / s.secsOnBrake
+	}
+	return s
+}
+
+func signf(x float64) int {
+	if x < 0 {
+		return -1
+	}
+	return 1
+}
+
+// sparkline of brake trace across [lo,hi]
+func brakeSpark(d analysis.Lap, lo, hi float64, n int) string {
+	blocks := []rune("▁▂▃▄▅▆▇█")
+	out := make([]rune, n)
+	for k := 0; k < n; k++ {
+		x := lo + (hi-lo)*float64(k)/float64(n-1)
+		v := analysis.Interp(d.Dist, d.Brk, x)
+		if v < 0 {
+			v = 0
+		}
+		if v > 1 {
+			v = 1
+		}
+		idx := int(v * float64(len(blocks)-1))
+		out[k] = blocks[idx]
+	}
+	return string(out)
+}
+
+func runBrake(args []string) {
+	if len(args) < 4 {
+		fmt.Println("usage: ibt brake <you.ibt> <lap> <ref.ibt> <lap>")
+		return
+	}
+	fY, lY := args[0], mustI(args[1])
+	fR, lR := args[2], mustI(args[3])
+	hY, err := ibt.Open(fY)
+	if err != nil {
+		panic(err)
+	}
+	hR, err := ibt.Open(fR)
+	if err != nil {
+		panic(err)
+	}
+	dtY := 1.0 / float64(hY.TickRate)
+	dtR := 1.0 / float64(hR.TickRate)
+	you := analysis.ExtractLap(hY, int32(lY))
+	ref := analysis.ExtractLap(hR, int32(lR))
+	if len(you.Dist) == 0 || len(ref.Dist) == 0 {
+		fmt.Println("brake: no samples for the requested lap(s) — check the lap numbers")
+		return
+	}
+
+	// corner set from the reference lap (auto-detected, named C1..Cn)
+	trackLen := ref.Dist[len(ref.Dist)-1]
+	rDist, rSpd := analysis.Resample(ref, 1000)
+	corners := analysis.DetectCorners(rDist, rSpd, analysis.DefaultCornerOpts())
+	for i := range corners {
+		if corners[i].Name == "" {
+			corners[i].Name = fmt.Sprintf("C%d", i+1)
+		}
+	}
+
+	// zones = whole lap, then a generous braking window around each corner apex.
+	// (satFrac/peak only count on-brake samples, so a wide window can't dilute
+	// them — it only guarantees the whole braking event is captured.)
+	type zone struct {
+		name   string
+		lo, hi float64
+	}
+	zones := []zone{{"WHOLE LAP (all braking)", 0, trackLen + 1}}
+	for _, c := range corners {
+		zones = append(zones, zone{
+			name: fmt.Sprintf("%-9s @%.0fm", c.Name, c.ApexDist),
+			lo:   c.ApexDist - 240,
+			hi:   c.ApexDist + 60,
+		})
+	}
+
+	// headline: saturation (mash-to-100%) vs fine mid-range modulation
+	fmt.Printf("%-24s | %-26s | %-26s\n", "ZONE", "YOU  peak sat%% fine%% jerk", "REF  peak sat%% fine%% jerk")
+	fmt.Println(strings.Repeat("-", 84))
+	for _, z := range zones {
+		y := brakeZone(you, dtY, z.lo, z.hi)
+		r := brakeZone(ref, dtR, z.lo, z.hi)
+		fmt.Printf("%-24s | %4.2f %5.0f %5.0f %5.1f | %4.2f %5.0f %5.0f %5.1f\n",
+			z.name,
+			y.peakBrake, y.satFrac*100, y.fineFrac*100, y.rmsRate,
+			r.peakBrake, r.satFrac*100, r.fineFrac*100, r.rmsRate)
+	}
+	fmt.Println("\nsat%% = share of on-brake time pinned >95% (mashed). fine%% = share in 15-85% (modulating).")
+	fmt.Println("jerk  = RMS brake-rate (higher = steppier application).")
+
+	// brake-trace sparklines for the two slowest corners (heaviest braking)
+	slow := make([]analysis.Corner, len(corners))
+	copy(slow, corners)
+	sort.Slice(slow, func(i, j int) bool { return slow[i].ApexSpeedKmh < slow[j].ApexSpeedKmh })
+	for i := 0; i < 2 && i < len(slow); i++ {
+		c := slow[i]
+		lo, hi := c.ApexDist-240, c.ApexDist+60
+		fmt.Printf("\nBRAKE TRACE — %s @%.0fm (%.0f-%.0fm), 60 chars:\n", c.Name, c.ApexDist, lo, hi)
+		fmt.Printf("YOU: %s\n", brakeSpark(you, lo, hi, 60))
+		fmt.Printf("REF: %s\n", brakeSpark(ref, lo, hi, 60))
+	}
+}

--- a/cmd/ibt/compare.go
+++ b/cmd/ibt/compare.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"strconv"
+
+	"github.com/jonsabados/saturdaysspinout/telemetry/analysis"
+	"github.com/jonsabados/saturdaysspinout/telemetry/ibt"
+)
+
+func runCompare(args []string) {
+	// args: fileYou lapYou fileRef lapRef
+	if len(args) < 4 {
+		fmt.Println("usage: ibt compare <you.ibt> <lap> <ref.ibt> <lap> [csv]")
+		return
+	}
+	fY, lY := args[0], mustI(args[1])
+	fR, lR := args[2], mustI(args[3])
+	hY, err := ibt.Open(fY)
+	if err != nil {
+		panic(err)
+	}
+	hR, err := ibt.Open(fR)
+	if err != nil {
+		panic(err)
+	}
+	you := analysis.ExtractLap(hY, int32(lY))
+	ref := analysis.ExtractLap(hR, int32(lR))
+	if len(you.Dist) == 0 || len(ref.Dist) == 0 {
+		fmt.Println("compare: no samples for the requested lap(s) — check the lap numbers")
+		return
+	}
+
+	trackLen := math.Min(you.Dist[len(you.Dist)-1], ref.Dist[len(ref.Dist)-1])
+	N := 1000
+	grid := make([]float64, N)
+	for i := range grid {
+		grid[i] = float64(i) / float64(N-1) * trackLen
+	}
+
+	// interpolate onto grid
+	type G struct{ t, sp, th, br, st []float64 }
+	mk := func(d analysis.Lap) G {
+		g := G{}
+		for _, x := range grid {
+			g.t = append(g.t, analysis.Interp(d.Dist, d.TElap, x))
+			g.sp = append(g.sp, analysis.Interp(d.Dist, d.Speed, x))
+			g.th = append(g.th, analysis.Interp(d.Dist, d.Thr, x))
+			g.br = append(g.br, analysis.Interp(d.Dist, d.Brk, x))
+			g.st = append(g.st, analysis.Interp(d.Dist, d.Steer, x))
+		}
+		return g
+	}
+	gY, gR := mk(you), mk(ref)
+
+	tYtot := you.TElap[len(you.TElap)-1]
+	tRtot := ref.TElap[len(ref.TElap)-1]
+	fmt.Printf("YOU  lap %d: %s over %.0fm\n", lY, fmtTime(tYtot), you.Dist[len(you.Dist)-1])
+	fmt.Printf("REF  lap %d: %s over %.0fm\n", lR, fmtTime(tRtot), ref.Dist[len(ref.Dist)-1])
+	fmt.Printf("RAW GAP: %+.3fs\n\n", tYtot-tRtot)
+
+	// delta-t trace (you - ref), both anchored at 0
+	delta := make([]float64, N)
+	for i := 0; i < N; i++ {
+		delta[i] = gY.t[i] - gR.t[i]
+	}
+
+	// corner detection on smoothed ref speed: local minima
+	sm := analysis.Smooth(gR.sp, 8)
+	type corner struct{ idx int }
+	var corners []corner
+	win := 25
+	for i := win; i < N-win; i++ {
+		isMin := true
+		for k := i - win; k <= i+win; k++ {
+			if sm[k] < sm[i] {
+				isMin = false
+				break
+			}
+		}
+		// require it be an actual slow point (< 250 km/h) and not adjacent dup
+		if isMin && sm[i]*3.6 < 255 {
+			if len(corners) == 0 || i-corners[len(corners)-1].idx > win {
+				corners = append(corners, corner{i})
+			}
+		}
+	}
+
+	fmt.Printf("=== CORNER-BY-CORNER (min speed & braking) ===\n")
+	fmt.Printf("%-12s %-9s %-9s %-8s  %-10s %-10s\n", "corner", "youKmh", "refKmh", "dSpd", "youBrake@", "refBrake@")
+	for ci, c := range corners {
+		i := c.idx
+		// find your local min speed near this corner (+-40 idx)
+		yMin, yIdx := 1e9, i
+		for k := i - 30; k <= i+30; k++ {
+			if k >= 0 && k < N && gY.sp[k] < yMin {
+				yMin = gY.sp[k]
+				yIdx = k
+			}
+		}
+		_ = yIdx
+		refKmh := gR.sp[i] * 3.6
+		youKmh := yMin * 3.6
+		// braking point: find onset of the braking zone preceding the apex.
+		// walk back from apex through any off-brake coast at the apex, into the
+		// braking zone, then back to where the brakes first came on.
+		bp := func(g G, apex int) float64 {
+			k := apex
+			for k > apex-160 && k > 0 && g.br[k] < 0.08 { // skip off-brake at apex
+				k--
+			}
+			for k > apex-160 && k > 0 && g.br[k] >= 0.08 { // back through braking zone
+				k--
+			}
+			return grid[k+1]
+		}
+		yBrk := bp(gY, i)
+		rBrk := bp(gR, i)
+		fmt.Printf("%-12s %-9.1f %-9.1f %+-8.1f %-10.0f %-10.0f\n",
+			fmt.Sprintf("C%d@%.0f", ci+1, grid[i]), youKmh, refKmh, youKmh-refKmh, yBrk, rBrk)
+	}
+
+	// cumulative delta by segment (10 equal-distance segments)
+	fmt.Printf("\n=== TIME GAIN/LOSS BY SEGMENT (lap split into 10) ===\n")
+	fmt.Printf("%-8s %-14s %-12s\n", "seg", "dist range", "d(this seg)")
+	segN := 10
+	for s := 0; s < segN; s++ {
+		i0 := s * N / segN
+		i1 := (s+1)*N/segN - 1
+		seg := delta[i1] - delta[i0]
+		bar := ""
+		n := int(math.Abs(seg) * 20)
+		for b := 0; b < n && b < 40; b++ {
+			bar += "#"
+		}
+		sign := "LOSS"
+		if seg < 0 {
+			sign = "gain"
+		}
+		fmt.Printf("%-8d %5.0f-%5.0f  %+7.3f %-5s %s\n", s+1, grid[i0], grid[i1], seg, sign, bar)
+	}
+	fmt.Printf("\nFINAL DELTA: %+.3fs\n", delta[N-1])
+
+	// driving-style aggregates
+	pct := func(g G, f func(i int) bool) float64 {
+		c := 0
+		for i := 0; i < N; i++ {
+			if f(i) {
+				c++
+			}
+		}
+		return 100 * float64(c) / float64(N)
+	}
+	fmt.Printf("\n=== DRIVING STYLE (%% of lap by distance) ===\n")
+	fmt.Printf("%-18s %-8s %-8s\n", "", "YOU", "REF")
+	fmt.Printf("%-18s %6.1f%%  %6.1f%%\n", "Full throttle", pct(gY, func(i int) bool { return gY.th[i] > 0.98 }), pct(gR, func(i int) bool { return gR.th[i] > 0.98 }))
+	fmt.Printf("%-18s %6.1f%%  %6.1f%%\n", "On brakes", pct(gY, func(i int) bool { return gY.br[i] > 0.08 }), pct(gR, func(i int) bool { return gR.br[i] > 0.08 }))
+	fmt.Printf("%-18s %6.1f%%  %6.1f%%\n", "Coasting", pct(gY, func(i int) bool { return gY.th[i] < 0.05 && gY.br[i] < 0.08 }), pct(gR, func(i int) bool { return gR.th[i] < 0.05 && gR.br[i] < 0.08 }))
+	fmt.Printf("%-18s %6.1f%%  %6.1f%%\n", "Trail (brk+steer)", pct(gY, func(i int) bool { return gY.br[i] > 0.08 && math.Abs(gY.st[i]) > 0.15 }), pct(gR, func(i int) bool { return gR.br[i] > 0.08 && math.Abs(gR.st[i]) > 0.15 }))
+
+	// throttle limited by rotation? where the ref is flat and you aren't, are you
+	// carrying more steering lock? if so the car isn't rotated and the throttle
+	// gap is a symptom — unwind the lock sooner, don't just "be flatter" (which
+	// over the kerb with the rear light is how you crash).
+	const rad2deg = 180.0 / math.Pi
+	var nLim int
+	var yLock, rLock float64
+	for i := 0; i < N; i++ {
+		if gR.th[i] > 0.98 && gY.th[i] < 0.90 {
+			nLim++
+			yLock += math.Abs(gY.st[i]) * rad2deg
+			rLock += math.Abs(gR.st[i]) * rad2deg
+		}
+	}
+	if nLim > 0 {
+		fmt.Printf("\n=== THROTTLE LIMITED BY ROTATION? ===\n")
+		fmt.Printf("At %d pts (%.0f%% of lap) ref is flat (>98%%) and you aren't (<90%%):\n",
+			nLim, 100*float64(nLim)/float64(N))
+		fmt.Printf("  your mean steering lock %.1f°  vs ref %.1f°  (%+.1f°)\n",
+			yLock/float64(nLim), rLock/float64(nLim), (yLock-rLock)/float64(nLim))
+		fmt.Println("  (more lock than ref => car not rotated; unwind sooner, don't just 'be flat')")
+	}
+
+	// dump aligned CSV for optional later plotting
+	if len(args) > 4 && args[4] == "csv" {
+		if err := os.MkdirAll("/tmp/ibt", 0o755); err != nil {
+			fmt.Println("compare: could not create csv dir:", err)
+			return
+		}
+		w, err := os.Create("/tmp/ibt/aligned.csv")
+		if err != nil {
+			fmt.Println("compare: could not write csv:", err)
+			return
+		}
+		fmt.Fprintln(w, "dist,delta,you_spd,ref_spd,you_thr,ref_thr,you_brk,ref_brk")
+		for i := 0; i < N; i++ {
+			fmt.Fprintf(w, "%.1f,%.4f,%.2f,%.2f,%.3f,%.3f,%.3f,%.3f\n",
+				grid[i], delta[i], gY.sp[i]*3.6, gR.sp[i]*3.6, gY.th[i], gR.th[i], gY.br[i], gR.br[i])
+		}
+		w.Close()
+		fmt.Println("\nwrote /tmp/ibt/aligned.csv")
+	}
+}
+
+func mustI(s string) int {
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}

--- a/cmd/ibt/consistency.go
+++ b/cmd/ibt/consistency.go
@@ -1,0 +1,288 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+
+	"github.com/jonsabados/saturdaysspinout/telemetry/analysis"
+	"github.com/jonsabados/saturdaysspinout/telemetry/ibt"
+)
+
+func mean(v []float64) float64 {
+	s := 0.0
+	for _, x := range v {
+		s += x
+	}
+	return s / float64(len(v))
+}
+func std(v []float64) float64 {
+	if len(v) < 2 {
+		return 0
+	}
+	m := mean(v)
+	s := 0.0
+	for _, x := range v {
+		s += (x - m) * (x - m)
+	}
+	return math.Sqrt(s / float64(len(v)-1))
+}
+func minmax(v []float64) (float64, float64) {
+	lo, hi := v[0], v[0]
+	for _, x := range v {
+		if x < lo {
+			lo = x
+		}
+		if x > hi {
+			hi = x
+		}
+	}
+	return lo, hi
+}
+
+// resample a lap onto a fixed grid; return speed(km/h), brake, elapsed-time arrays
+func gridLap(h *ibt.IBT, lap int32, grid []float64) (spd, brk, tel []float64) {
+	d := analysis.ExtractLap(h, lap)
+	if len(d.Dist) < 10 {
+		return nil, nil, nil
+	}
+	for _, x := range grid {
+		spd = append(spd, analysis.Interp(d.Dist, d.Speed, x)*3.6)
+		brk = append(brk, analysis.Interp(d.Dist, d.Brk, x))
+		tel = append(tel, analysis.Interp(d.Dist, d.TElap, x))
+	}
+	return
+}
+
+func runConsistency(args []string) {
+	if len(args) < 1 {
+		fmt.Println("usage: ibt consistency <file.ibt> [prominenceKmh] [spacingM] [maxApexKmh] [smoothWin] [gridN]")
+		return
+	}
+	h, err := ibt.Open(args[0])
+	if err != nil {
+		panic(err)
+	}
+	dt := 1.0 / float64(h.TickRate)
+	laps := analysis.FlyingLaps(h)
+	if len(laps) == 0 {
+		fmt.Println("no flying laps found")
+		return
+	}
+
+	// reference lap for corner detection + track length = fastest flyer
+	best := laps[0]
+	for _, l := range laps {
+		if l.Dur < best.Dur {
+			best = l
+		}
+	}
+	refLap := analysis.ExtractLap(h, best.Num)
+	trackLen := refLap.Dist[len(refLap.Dist)-1]
+	N := 800
+	if len(args) >= 6 {
+		if v, e := strconv.Atoi(args[5]); e == nil && v >= 100 {
+			N = v
+		}
+	}
+	grid := make([]float64, N)
+	for i := range grid {
+		grid[i] = float64(i) / float64(N-1) * trackLen
+	}
+	rDist, rSpd := analysis.Resample(refLap, N)
+	// optional detection tuning: consistency <file> [prominenceKmh] [spacingM] [maxApexKmh]
+	opt := analysis.DefaultCornerOpts()
+	if len(args) >= 2 {
+		if v, e := strconv.ParseFloat(args[1], 64); e == nil {
+			opt.ProminenceKmh = v
+		}
+	}
+	if len(args) >= 3 {
+		if v, e := strconv.ParseFloat(args[2], 64); e == nil {
+			opt.MinSpacingM = v
+		}
+	}
+	if len(args) >= 4 {
+		if v, e := strconv.ParseFloat(args[3], 64); e == nil {
+			opt.MaxApexSpeedKmh = v
+		}
+	}
+	if len(args) >= 5 {
+		if v, e := strconv.Atoi(args[4]); e == nil {
+			opt.SmoothWin = v
+		}
+	}
+	corners := analysis.DetectCorners(rDist, rSpd, opt)
+	for i := range corners {
+		if corners[i].Name == "" {
+			corners[i].Name = fmt.Sprintf("C%d", i+1)
+		}
+	}
+
+	// collect per-lap series
+	type lapGrid struct {
+		num      int32
+		dur      float64
+		spd, brk []float64
+		tel      []float64
+	}
+	var lgs []lapGrid
+	var durs []float64
+	for _, li := range laps {
+		s, b, t := gridLap(h, li.Num, grid)
+		if s == nil {
+			continue
+		}
+		lgs = append(lgs, lapGrid{li.Num, li.Dur, s, b, t})
+		durs = append(durs, li.Dur)
+	}
+
+	fmt.Printf("Flying laps analyzed: %d  (laptime %s ± %.3fs, range %s..%s)\n",
+		len(lgs), fmtTime(mean(durs)), std(durs), fmtSecShort(minSlice(durs)), fmtSecShort(maxSlice(durs)))
+	fmt.Printf("Detected %d corners on lap %d (%s), track length %.0fm\n",
+		len(corners), best.Num, fmtSecShort(best.Dur), trackLen)
+
+	// per-corner min speed & brake onset across laps
+	fmt.Printf("\n=== PER-CORNER CONSISTENCY (min speed, km/h) ===\n")
+	fmt.Printf("%-12s %7s %8s %7s %14s %10s\n", "corner", "apex(m)", "mean", "STDDEV", "range", "brakeSTD(m)")
+	type row struct {
+		name   string
+		spdStd float64
+		line   string
+	}
+	brakeWin := int(160.0 / trackLen * float64(N))
+	win := int(60.0 / trackLen * float64(N)) // ±60m window
+	var rows []row
+	for _, c := range corners {
+		gi := int(c.ApexDist / trackLen * float64(N-1))
+		var mins, brakePts []float64
+		for _, lg := range lgs {
+			// min speed near apex
+			mn := 1e9
+			for k := gi - win; k <= gi+win; k++ {
+				if k >= 0 && k < N && lg.spd[k] < mn {
+					mn = lg.spd[k]
+				}
+			}
+			mins = append(mins, mn)
+			// brake onset: back from apex through off-brake, then through braking
+			// zone. Only a valid point if braking actually happened AND the walk
+			// found the off-brake edge inside the window (didn't clamp at the
+			// boundary) — otherwise brakeSTD would read a false 0.0.
+			kk := gi
+			for kk > gi-brakeWin && kk > 0 && lg.brk[kk] < 0.08 {
+				kk--
+			}
+			braked := kk > gi-brakeWin && kk > 0 && lg.brk[kk] >= 0.08
+			for kk > gi-brakeWin && kk > 0 && lg.brk[kk] >= 0.08 {
+				kk--
+			}
+			if braked && kk > gi-brakeWin && kk > 0 {
+				brakePts = append(brakePts, grid[kk+1])
+			}
+		}
+		lo, hi := minmax(mins)
+		brakeStd := "   n/a" // no braking here, or onset outside the window
+		if len(brakePts) >= 2 {
+			brakeStd = fmt.Sprintf("%6.1f", std(brakePts))
+		}
+		rows = append(rows, row{c.Name, std(mins),
+			fmt.Sprintf("%-12s %7.0f %8.1f %7.2f %6.1f-%-6.1f %10s",
+				c.Name, c.ApexDist, mean(mins), std(mins), lo, hi, brakeStd)})
+	}
+	for _, r := range rows {
+		fmt.Println(r.line)
+	}
+	// rank worst
+	sort.Slice(rows, func(i, j int) bool { return rows[i].spdStd > rows[j].spdStd })
+	fmt.Printf("\nLeast consistent corners (min-speed stddev): ")
+	for i := 0; i < 3 && i < len(rows); i++ {
+		fmt.Printf("%s(±%.1f) ", rows[i].name, rows[i].spdStd)
+	}
+	fmt.Println()
+
+	// per-sector TIME variance (12 sectors) -> where lap-to-lap time swings most
+	fmt.Printf("\n=== SECTOR TIME CONSISTENCY (12 sectors) ===\n")
+	fmt.Printf("%-6s %-13s %-8s %-8s %s\n", "sector", "dist", "meanT", "STDDEV", "")
+	segN := 12
+	type seg struct {
+		i         int
+		lo, hi    float64
+		std, mean float64
+	}
+	var segs []seg
+	for s := 0; s < segN; s++ {
+		i0 := s * N / segN
+		i1 := (s+1)*N/segN - 1
+		var times []float64
+		for _, lg := range lgs {
+			times = append(times, lg.tel[i1]-lg.tel[i0])
+		}
+		segs = append(segs, seg{s, grid[i0], grid[i1], std(times), mean(times)})
+	}
+	// find max std for bar scaling
+	maxStd := 0.0
+	for _, sg := range segs {
+		if sg.std > maxStd {
+			maxStd = sg.std
+		}
+	}
+	for _, sg := range segs {
+		bar := ""
+		n := int(sg.std / maxStd * 30)
+		for b := 0; b < n; b++ {
+			bar += "#"
+		}
+		note := cornerIn(sg.lo, sg.hi, corners)
+		fmt.Printf("%-6d %5.0f-%-5.0f %7.2fs %7.3fs %s %s\n", sg.i+1, sg.lo, sg.hi, sg.mean, sg.std, bar, note)
+	}
+
+	// brake saturation across laps at the slowest corner (heaviest braking =
+	// where the mash-to-100% hardware tendency shows up)
+	if len(corners) == 0 {
+		fmt.Printf("\nno corners detected on the reference lap - skipping brake saturation\n")
+		return
+	}
+	slow := corners[0]
+	for _, c := range corners {
+		if c.ApexSpeedKmh < slow.ApexSpeedKmh {
+			slow = c
+		}
+	}
+	zoneLo, zoneHi := slow.ApexDist-230, slow.ApexDist+120
+	fmt.Printf("\n=== %s BRAKE SATURATION across every flying lap (slowest corner @ %.0fm) ===\n", slow.Name, slow.ApexDist)
+	var sats, peaks []float64
+	for _, li := range laps {
+		d := analysis.ExtractLap(h, li.Num)
+		bz := brakeZone(d, dt, zoneLo, zoneHi)
+		sats = append(sats, bz.satFrac*100)
+		peaks = append(peaks, bz.peakBrake)
+		fmt.Printf("  lap %2d: peak %.2f  sat %4.0f%%  (%s)\n", li.Num, bz.peakBrake, bz.satFrac*100, fmtSecShort(li.Dur))
+	}
+	fmt.Printf("  --> peak %.2f±%.2f, saturation %.0f%%±%.0f%% of the braking zone\n",
+		mean(peaks), std(peaks), mean(sats), std(sats))
+	nMash := 0
+	for _, p := range peaks {
+		if p > 0.98 {
+			nMash++
+		}
+	}
+	fmt.Printf("  --> hit >=98%% brake in %d of %d laps\n", nMash, len(peaks))
+}
+
+func cornerIn(lo, hi float64, corners []analysis.Corner) string {
+	for _, c := range corners {
+		if c.ApexDist >= lo && c.ApexDist <= hi {
+			return "<- " + c.Name
+		}
+	}
+	return ""
+}
+
+func fmtSecShort(s float64) string {
+	m := int(s) / 60
+	return fmt.Sprintf("%d:%05.2f", m, s-float64(m*60))
+}
+func minSlice(v []float64) float64 { lo, _ := minmax(v); return lo }
+func maxSlice(v []float64) float64 { _, hi := minmax(v); return hi }

--- a/cmd/ibt/journal.go
+++ b/cmd/ibt/journal.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/jonsabados/saturdaysspinout/telemetry/analysis"
+	"github.com/jonsabados/saturdaysspinout/telemetry/ibt"
+)
+
+// journalRoot is relative to the repo root (run ibt from there). Gitignored.
+const journalRoot = "claudecoach/journal"
+
+// journalRecord is one appended line: a session summary plus provenance.
+type journalRecord struct {
+	Date   string `json:"date"`   // "YYYY-MM-DD HH-MM-SS" from the filename, else file mtime
+	Source string `json:"source"` // .ibt basename
+	analysis.SessionSummary
+}
+
+func runJournal(args []string) {
+	if len(args) < 2 {
+		fmt.Println("usage: ibt journal <add|trends> <session.ibt | track-name>")
+		return
+	}
+	switch args[0] {
+	case "add":
+		journalAdd(args[1])
+	case "trends":
+		journalTrends(args[1])
+	default:
+		fmt.Printf("unknown journal subcommand %q (want add|trends)\n", args[0])
+	}
+}
+
+func journalAdd(path string) {
+	h, err := ibt.Open(path)
+	if err != nil {
+		panic(err)
+	}
+	sum := analysis.SummarizeSession(h, analysis.DefaultCornerOpts())
+	if sum.FlyingLaps == 0 {
+		fmt.Println("no flying laps in this session — nothing to journal")
+		return
+	}
+	rec := journalRecord{Date: parseSessionDate(path), Source: filepath.Base(path), SessionSummary: sum}
+
+	dir := filepath.Join(journalRoot, slug(sum.Track))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		panic(err)
+	}
+	file := filepath.Join(dir, "sessions.jsonl")
+
+	// dedupe by source so the skill can re-run safely
+	for _, r := range readRecords(file) {
+		if r.Source == rec.Source {
+			fmt.Printf("already journaled %s (%s) — skipping\n", rec.Source, file)
+			return
+		}
+	}
+
+	line, err := json.Marshal(rec)
+	if err != nil {
+		panic(err)
+	}
+	f, err := os.OpenFile(file, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+	if _, err := f.Write(append(line, '\n')); err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("journaled %s -> %s\n", rec.Source, file)
+	fmt.Printf("  %s / %s / %s\n", sum.Track, sum.Car, sum.Driver)
+	fmt.Printf("  %d flying laps, best %s, mean %s ±%.2fs, %d corners\n",
+		sum.FlyingLaps, fmtTime(sum.BestLapSec), fmtTime(sum.MeanLapSec), sum.StdLapSec, len(sum.Corners))
+}
+
+func journalTrends(arg string) {
+	// resolve the track: a file path -> read its TrackName; otherwise a track name
+	track := arg
+	if strings.HasSuffix(strings.ToLower(arg), ".ibt") {
+		if h, err := ibt.Open(arg); err == nil {
+			track = analysis.TrackName(h)
+		}
+	}
+	file := filepath.Join(journalRoot, slug(track), "sessions.jsonl")
+	recs := readRecords(file)
+	if len(recs) == 0 {
+		fmt.Printf("no journal entries for %q (%s)\n", track, file)
+		return
+	}
+	sort.Slice(recs, func(i, j int) bool { return recs[i].Date < recs[j].Date })
+
+	latest := recs[len(recs)-1]
+	fmt.Printf("=== TRENDS: %s (%s) — %d sessions ===\n\n", latest.Track, latest.Car, len(recs))
+	fmt.Printf("%-19s %5s  %-9s  %-13s %-8s %s\n", "date", "laps", "best", "mean±std", "fuel", "session")
+	for _, r := range recs {
+		fmt.Printf("%-19s %5d  %-9s  %s ±%.2fs  %-8s %s\n",
+			r.Date, r.FlyingLaps, fmtTime(r.BestLapSec), fmtTime(r.MeanLapSec), r.StdLapSec, r.Fuel, r.SessionType)
+	}
+	fmt.Println("(compare like-for-like: same fuel + session type, or the trend is an artifact.)")
+
+	// per-corner min-speed across sessions, matched by nearest apex distance to
+	// the latest session's corners (robust to detection C-numbering shifts).
+	fmt.Printf("\nCORNER MIN-SPEED (km/h) BY SESSION  [matched by apex distance]\n")
+	fmt.Printf("%-16s", "corner")
+	for _, r := range recs {
+		fmt.Printf(" %-10s", shortDate(r.Date))
+	}
+	fmt.Println()
+	for _, lc := range latest.Corners {
+		fmt.Printf("%-16s", fmt.Sprintf("%s@%.0f", lc.Name, lc.ApexDist))
+		for _, r := range recs {
+			val := "   -"
+			bestD := 121.0
+			for _, c := range r.Corners {
+				if d := math.Abs(c.ApexDist - lc.ApexDist); d < bestD {
+					bestD = d
+					val = fmt.Sprintf("%.1f", c.MinSpeedMean)
+				}
+			}
+			fmt.Printf(" %-10s", val)
+		}
+		fmt.Println()
+	}
+	fmt.Println("\n(auto-detected corners are lap-dependent; a per-track overlay will stabilize this.)")
+}
+
+func parseSessionDate(path string) string {
+	base := filepath.Base(path)
+	if m := regexp.MustCompile(`(\d{4}-\d{2}-\d{2}) (\d{2}-\d{2}-\d{2})`).FindStringSubmatch(base); m != nil {
+		return m[1] + " " + m[2]
+	}
+	if fi, err := os.Stat(path); err == nil {
+		return fi.ModTime().Format("2006-01-02 15-04-05")
+	}
+	return "unknown"
+}
+
+func shortDate(d string) string {
+	if len(d) >= 10 {
+		return d[:10]
+	}
+	return d
+}
+
+func slug(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = regexp.MustCompile(`[^a-z0-9]+`).ReplaceAllString(s, "-")
+	return strings.Trim(s, "-")
+}
+
+func readRecords(file string) []journalRecord {
+	f, err := os.Open(file)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	var out []journalRecord
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 1024*1024), 8*1024*1024)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var r journalRecord
+		if err := json.Unmarshal([]byte(line), &r); err == nil {
+			out = append(out, r)
+		}
+	}
+	return out
+}

--- a/cmd/ibt/main.go
+++ b/cmd/ibt/main.go
@@ -1,0 +1,163 @@
+// Command ibt is a local iRacing telemetry coaching tool. It decodes .ibt files
+// (via the telemetry/ibt package) and prints lap tables, channel listings, and
+// position-aligned driver-vs-reference analyses (compare/brake/consistency/section).
+//
+// Not part of the deployed app — a personal analysis CLI driven by the
+// claudecoach skill.
+package main
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/jonsabados/saturdaysspinout/telemetry/ibt"
+)
+
+func fmtTime(s float64) string {
+	if s <= 0 {
+		return "--"
+	}
+	m := int(s) / 60
+	sec := s - float64(m*60)
+	return fmt.Sprintf("%d:%06.3f", m, sec)
+}
+
+func main() {
+	if len(os.Args) < 3 {
+		fmt.Println("usage: ibt <summary|channels|compare|brake|consistency|section|journal> <file> ...")
+		fmt.Println("  summary      <file>")
+		fmt.Println("  channels     <file>")
+		fmt.Println("  consistency  <file> [prominenceKmh] [spacingM] [maxApexKmh] [smoothWin] [gridN]")
+		fmt.Println("  compare      <you.ibt> <lap> <ref.ibt> <lap> [csv]")
+		fmt.Println("  brake        <you.ibt> <lap> <ref.ibt> <lap>")
+		fmt.Println("  section      <you.ibt> <lap> <ref.ibt> <lap> <loM> <hiM>")
+		fmt.Println("  journal add    <session.ibt>          (append session summary to the journal)")
+		fmt.Println("  journal trends <session.ibt|track>     (show cross-session trends)")
+		os.Exit(1)
+	}
+	mode := os.Args[1]
+	if mode == "compare" {
+		runCompare(os.Args[2:])
+		return
+	}
+	if mode == "brake" {
+		runBrake(os.Args[2:])
+		return
+	}
+	if mode == "consistency" {
+		runConsistency(os.Args[2:])
+		return
+	}
+	if mode == "section" {
+		runSection(os.Args[2:])
+		return
+	}
+	if mode == "journal" {
+		runJournal(os.Args[2:])
+		return
+	}
+	h, err := ibt.Open(os.Args[2])
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("ver=%d tickRate=%dHz numVars=%d bufLen=%d samples=%d (~%.1f min)\n",
+		h.Ver, h.TickRate, h.NumVars, h.BufLen, h.NumSamples, float64(h.NumSamples)/float64(h.TickRate)/60)
+
+	yaml := h.SessionYAML()
+	for _, key := range []string{"TrackName", "TrackDisplayName", "TrackConfigName", "DriverSetupName"} {
+		if m := regexp.MustCompile(key + `: ?(.*)`).FindStringSubmatch(yaml); m != nil {
+			fmt.Printf("  %s: %s\n", key, strings.TrimSpace(m[1]))
+		}
+	}
+	// driver / car
+	if m := regexp.MustCompile(`UserName: ?(.*)`).FindStringSubmatch(yaml); m != nil {
+		fmt.Printf("  Driver: %s\n", strings.TrimSpace(m[1]))
+	}
+	if m := regexp.MustCompile(`CarScreenName: ?(.*)`).FindStringSubmatch(yaml); m != nil {
+		fmt.Printf("  Car: %s\n", strings.TrimSpace(m[1]))
+	}
+	// Conditions — establish comparability BEFORE comparing laps. Fuel load,
+	// track temp, and session type each change what a lap time means; comparing
+	// across them (e.g. an 8L quali lap vs a 55L race lap) silently misleads.
+	fmt.Println("  --- conditions (must match to compare laps) ---")
+	for _, key := range []string{"SessionType", "SessionName", "FuelLevel", "BrakePressureBias", "TrackSurfaceTemp", "TrackAirTemp"} {
+		if m := regexp.MustCompile(key + `: ?(.*)`).FindStringSubmatch(yaml); m != nil {
+			fmt.Printf("  %-17s %s\n", key+":", strings.TrimSpace(m[1]))
+		}
+	}
+
+	if mode == "channels" {
+		names := make([]string, 0, len(h.VarList))
+		for _, v := range h.VarList {
+			names = append(names, fmt.Sprintf("%-28s cnt=%d %-8s %s", v.Name, v.Count, v.Unit, v.Desc))
+		}
+		sort.Strings(names)
+		for _, n := range names {
+			fmt.Println(n)
+		}
+		return
+	}
+
+	// summary: lap table via Lap channel transitions
+	lapV, ok := h.Vars["Lap"]
+	stV, ok2 := h.Vars["SessionTime"]
+	pctV := h.Vars["LapDistPct"]
+	spdV := h.Vars["Speed"]
+	onTrackV, hasOT := h.Vars["IsOnTrack"]
+	if !ok || !ok2 {
+		fmt.Println("missing Lap/SessionTime channels")
+		return
+	}
+	type lapRow struct {
+		lap        int32
+		start, end float64
+		minPct     float64
+		maxSpeed   float64
+	}
+	var laps []lapRow
+	curLap := h.Int(lapV, 0)
+	lapStart := h.Float(stV, 0)
+	maxSpd := 0.0
+	for i := 1; i < h.NumSamples; i++ {
+		if hasOT && h.Int(onTrackV, i) == 0 {
+			// still track transitions, but note pit/off
+		}
+		s := h.Float(spdV, i)
+		if s > maxSpd {
+			maxSpd = s
+		}
+		l := h.Int(lapV, i)
+		if l != curLap {
+			t := h.Float(stV, i)
+			laps = append(laps, lapRow{curLap, lapStart, t, 0, maxSpd})
+			curLap = l
+			lapStart = t
+			maxSpd = 0
+		}
+	}
+	_ = pctV
+	fmt.Printf("\n%-5s %-12s %s\n", "Lap", "LapTime", "MaxSpeed(km/h)")
+	best := lapRow{lap: -1}
+	bestTime := 1e9
+	for _, lr := range laps {
+		dur := lr.end - lr.start
+		mark := ""
+		if dur > 60 && dur < 300 && dur < bestTime {
+			bestTime = dur
+			best = lr
+			_ = best
+		}
+		if dur > 60 && dur < 300 {
+			mark = ""
+		} else {
+			mark = "  (out/in/pit or partial)"
+		}
+		fmt.Printf("%-5d %-12s %6.1f%s\n", lr.lap, fmtTime(dur), lr.maxSpeed*3.6, mark)
+	}
+	if bestTime < 1e9 {
+		fmt.Printf("\nBEST FLYING LAP: lap %d  %s\n", best.lap, fmtTime(bestTime))
+	}
+}

--- a/cmd/ibt/section.go
+++ b/cmd/ibt/section.go
@@ -1,0 +1,349 @@
+package main
+
+// The "section" command: a deep-dive over an arbitrary distance window
+// [loM,hiM] of the lap — speed/throttle modulation, steering lock, gear, GPS
+// line deviation vs the reference, and exit commitment.
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+
+	"github.com/jonsabados/saturdaysspinout/telemetry/analysis"
+	"github.com/jonsabados/saturdaysspinout/telemetry/ibt"
+)
+
+// haversine distance in meters between two lat/lon (decimal degrees)
+func haversine(lat1, lon1, lat2, lon2 float64) float64 {
+	const R = 6371000.0
+	p1 := lat1 * math.Pi / 180
+	p2 := lat2 * math.Pi / 180
+	dp := (lat2 - lat1) * math.Pi / 180
+	dl := (lon2 - lon1) * math.Pi / 180
+	a := math.Sin(dp/2)*math.Sin(dp/2) + math.Cos(p1)*math.Cos(p2)*math.Sin(dl/2)*math.Sin(dl/2)
+	return 2 * R * math.Asin(math.Sqrt(a))
+}
+
+// throttle modulation stats within [lo,hi]
+type thrStat struct {
+	fullFrac, fineFrac, liftFrac float64
+	lifts                        int
+	jerk                         float64
+}
+
+func throttleZone(d analysis.Lap, dt, lo, hi float64) thrStat {
+	var s thrStat
+	n, nFull, nFine, nLift := 0, 0, 0, 0
+	var sumRate2 float64
+	wasUp := false
+	for i := 1; i < len(d.Dist); i++ {
+		if d.Dist[i] < lo || d.Dist[i] > hi {
+			continue
+		}
+		t := d.Thr[i]
+		n++
+		if t > 0.98 {
+			nFull++
+		}
+		if t >= 0.15 && t <= 0.85 {
+			nFine++
+		}
+		if t < 0.05 {
+			nLift++
+			if wasUp {
+				s.lifts++
+			}
+			wasUp = false
+		} else if t > 0.30 {
+			wasUp = true
+		}
+		delta := d.Thr[i] - d.Thr[i-1]
+		sumRate2 += delta * delta
+	}
+	if n > 0 {
+		s.fullFrac = float64(nFull) / float64(n)
+		s.fineFrac = float64(nFine) / float64(n)
+		s.liftFrac = float64(nLift) / float64(n)
+		s.jerk = math.Sqrt(sumRate2/float64(n)) / dt
+	}
+	return s
+}
+
+func spark(vals []float64, vmin, vmax float64) string {
+	blocks := []rune("▁▂▃▄▅▆▇█")
+	out := make([]rune, len(vals))
+	for i, v := range vals {
+		f := (v - vmin) / (vmax - vmin)
+		if f < 0 {
+			f = 0
+		}
+		if f > 1 {
+			f = 1
+		}
+		out[i] = blocks[int(f*float64(len(blocks)-1))]
+	}
+	return string(out)
+}
+
+func mustF(s string) float64 {
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+func runSection(args []string) {
+	// args: fileYou lapYou fileRef lapRef loM hiM
+	if len(args) < 6 {
+		fmt.Println("usage: ibt section <you.ibt> <lap> <ref.ibt> <lap> <loM> <hiM>")
+		return
+	}
+	fY, lY := args[0], mustI(args[1])
+	fR, lR := args[2], mustI(args[3])
+	lo, hi := mustF(args[4]), mustF(args[5])
+	hY, err := ibt.Open(fY)
+	if err != nil {
+		panic(err)
+	}
+	hR, err := ibt.Open(fR)
+	if err != nil {
+		panic(err)
+	}
+	dtY := 1.0 / float64(hY.TickRate)
+	dtR := 1.0 / float64(hR.TickRate)
+	you := analysis.ExtractLap(hY, int32(lY))
+	ref := analysis.ExtractLap(hR, int32(lR))
+	if len(you.Dist) == 0 || len(ref.Dist) == 0 {
+		fmt.Println("section: no samples for the requested lap(s) — check the lap numbers")
+		return
+	}
+
+	N := int((hi - lo) / 14)
+	if N < 20 {
+		N = 20
+	}
+	grid := make([]float64, N)
+	for i := range grid {
+		grid[i] = lo + (hi-lo)*float64(i)/float64(N-1)
+	}
+	iy := func(d analysis.Lap, ch []float64) []float64 {
+		out := make([]float64, N)
+		for i, x := range grid {
+			out[i] = analysis.Interp(d.Dist, ch, x)
+		}
+		return out
+	}
+	ySpd := iy(you, you.Speed)
+	rSpd := iy(ref, ref.Speed)
+	yThr := iy(you, you.Thr)
+	rThr := iy(ref, ref.Thr)
+
+	// auto-scale the speed sparkline to the data in the window
+	smin, smax := math.Inf(1), math.Inf(-1)
+	for i := 0; i < N; i++ {
+		for _, v := range []float64{ySpd[i] * 3.6, rSpd[i] * 3.6} {
+			if v < smin {
+				smin = v
+			}
+			if v > smax {
+				smax = v
+			}
+		}
+	}
+
+	fmt.Printf("=== SECTION %.0f-%.0fm  (each char ~%.0fm) ===\n\n", lo, hi, (hi-lo)/float64(N))
+	fmt.Printf("SPEED (%.0f-%.0f km/h):\n", smin, smax)
+	fmt.Printf("YOU %s\n", spark(scale(ySpd, 3.6), smin, smax))
+	fmt.Printf("REF %s\n", spark(scale(rSpd, 3.6), smin, smax))
+	fmt.Printf("THROTTLE (0-100%%):\n")
+	fmt.Printf("YOU %s\n", spark(yThr, 0, 1))
+	fmt.Printf("REF %s\n\n", spark(rThr, 0, 1))
+
+	// sub-apex speeds at ref speed minima within the window
+	fmt.Printf("=== SUB-APEX SPEED (you vs ref) ===\n")
+	subApex := detectMinima(scale(rSpd, 3.6), grid, 4)
+	for _, ai := range subApex {
+		yg := analysis.Nearest(you.Dist, you.Gear, grid[ai])
+		rg := analysis.Nearest(ref.Dist, ref.Gear, grid[ai])
+		fmt.Printf("  %.0fm: you %.1f  ref %.1f  (%+.1f km/h)  gear you %.0f ref %.0f\n",
+			grid[ai], ySpd[ai]*3.6, rSpd[ai]*3.6, (ySpd[ai]-rSpd[ai])*3.6, yg, rg)
+	}
+
+	// throttle modulation stats in the window
+	ty := throttleZone(you, dtY, lo, hi)
+	tr := throttleZone(ref, dtR, lo, hi)
+	fmt.Printf("\n=== THROTTLE MODULATION ===\n")
+	fmt.Printf("%-18s %-8s %-8s\n", "", "YOU", "REF")
+	fmt.Printf("%-18s %6.0f%%  %6.0f%%   (pinned wide open)\n", "Full throttle", ty.fullFrac*100, tr.fullFrac*100)
+	fmt.Printf("%-18s %6.0f%%  %6.0f%%   (mid-range balance)\n", "Fine (15-85%)", ty.fineFrac*100, tr.fineFrac*100)
+	fmt.Printf("%-18s %6.0f%%  %6.0f%%   (fully off gas)\n", "Off throttle", ty.liftFrac*100, tr.liftFrac*100)
+	fmt.Printf("%-18s %6d   %6d     (full lift-offs)\n", "Lift events", ty.lifts, tr.lifts)
+	fmt.Printf("%-18s %6.1f   %6.1f     (higher=steppier)\n", "Throttle jerk", ty.jerk, tr.jerk)
+
+	// steering lock (deg) over the window. Carrying more lock than the reference
+	// where it's on the throttle means the car isn't rotated — a throttle gap is
+	// then a symptom (unwind the lock sooner), not "just be flatter".
+	const rad2deg = 180.0 / math.Pi
+	yMeanLock, yPeakLock := absStats(iy(you, you.Steer), rad2deg)
+	rMeanLock, rPeakLock := absStats(iy(ref, ref.Steer), rad2deg)
+	fmt.Printf("\n=== STEERING LOCK (deg) ===\n")
+	fmt.Printf("%-14s %6s %6s\n", "", "YOU", "REF")
+	fmt.Printf("%-14s %6.1f %6.1f\n", "mean |lock|", yMeanLock, rMeanLock)
+	fmt.Printf("%-14s %6.1f %6.1f\n", "peak |lock|", yPeakLock, rPeakLock)
+
+	// GPS line deviation vs ref
+	fmt.Printf("\n=== LINE DEVIATION vs reference (GPS, meters apart at same track pos) ===\n")
+	var devs []float64
+	maxDev, maxAt := 0.0, 0.0
+	for _, x := range grid {
+		yl := analysis.Interp(you.Dist, you.Lat, x)
+		yo := analysis.Interp(you.Dist, you.Lon, x)
+		rl := analysis.Interp(ref.Dist, ref.Lat, x)
+		ro := analysis.Interp(ref.Dist, ref.Lon, x)
+		dv := haversine(yl, yo, rl, ro)
+		devs = append(devs, dv)
+		if dv > maxDev {
+			maxDev = dv
+			maxAt = x
+		}
+	}
+	fmt.Printf("  mean %.1fm off ref line, max %.1fm at %.0fm\n", mean(devs), maxDev, maxAt)
+	fmt.Printf("  deviation trace: %s\n", spark(devs, 0, maxDev))
+
+	// exit commitment: full-throttle resume after the last sub-apex in the window
+	exitFrom := lo
+	if len(subApex) > 0 {
+		exitFrom = grid[subApex[len(subApex)-1]]
+	}
+	exitTo := hi + 400
+	fmt.Printf("\n=== EXIT — full-throttle resume after %.0fm ===\n", exitFrom)
+	fmt.Printf("  you: %.0fm   ref: %.0fm   (earlier=better)\n",
+		fullThrottleResume(you, exitFrom, exitTo), fullThrottleResume(ref, exitFrom, exitTo))
+
+	// consistency across your flying laps within the window
+	fmt.Printf("\n=== YOUR CONSISTENCY through the section (all flying laps) ===\n")
+	laps := analysis.FlyingLaps(hY)
+	subDist := make([]float64, len(subApex))
+	for i, ai := range subApex {
+		subDist[i] = grid[ai]
+	}
+	perApex := make([][]float64, len(subDist))
+	var resumes []float64
+	latByPt := make([][]float64, N)
+	lonByPt := make([][]float64, N)
+	for _, li := range laps {
+		d := analysis.ExtractLap(hY, li.Num)
+		for i, sd := range subDist {
+			mn := 1e9
+			for _, x := range gridAround(sd, 40, 15) {
+				v := analysis.Interp(d.Dist, d.Speed, x) * 3.6
+				if v < mn {
+					mn = v
+				}
+			}
+			perApex[i] = append(perApex[i], mn)
+		}
+		resumes = append(resumes, fullThrottleResume(d, exitFrom, exitTo))
+		for i, x := range grid {
+			latByPt[i] = append(latByPt[i], analysis.Interp(d.Dist, d.Lat, x))
+			lonByPt[i] = append(lonByPt[i], analysis.Interp(d.Dist, d.Lon, x))
+		}
+	}
+	for i, sd := range subDist {
+		lo2, hi2 := minmax(perApex[i])
+		fmt.Printf("  apex %.0fm: %.1f ± %.1f km/h  (range %.1f-%.1f)\n", sd, mean(perApex[i]), std(perApex[i]), lo2, hi2)
+	}
+	fmt.Printf("  throttle-resume: %.0f ± %.0fm across laps\n", mean(resumes), std(resumes))
+	var wander []float64
+	maxW, maxWat := 0.0, 0.0
+	for i := 0; i < N; i++ {
+		mlat := mean(latByPt[i])
+		mlon := mean(lonByPt[i])
+		var d2 []float64
+		for k := range latByPt[i] {
+			d2 = append(d2, haversine(latByPt[i][k], lonByPt[i][k], mlat, mlon))
+		}
+		w := mean(d2)
+		wander = append(wander, w)
+		if w > maxW {
+			maxW = w
+			maxWat = grid[i]
+		}
+	}
+	fmt.Printf("  line wander: mean %.1fm, worst %.1fm at %.0fm\n", mean(wander), maxW, maxWat)
+	fmt.Printf("  wander trace: %s\n", spark(wander, 0, maxW))
+}
+
+// absStats returns the mean and peak of |v|*scale.
+func absStats(v []float64, scaleF float64) (mean, peak float64) {
+	if len(v) == 0 {
+		return 0, 0
+	}
+	sum := 0.0
+	for _, x := range v {
+		a := math.Abs(x) * scaleF
+		sum += a
+		if a > peak {
+			peak = a
+		}
+	}
+	return sum / float64(len(v)), peak
+}
+
+func scale(v []float64, f float64) []float64 {
+	out := make([]float64, len(v))
+	for i := range v {
+		out[i] = v[i] * f
+	}
+	return out
+}
+
+func detectMinima(v, grid []float64, win int) []int {
+	var out []int
+	for i := win; i < len(v)-win; i++ {
+		isMin := true
+		for k := i - win; k <= i+win; k++ {
+			if v[k] < v[i] {
+				isMin = false
+				break
+			}
+		}
+		if isMin {
+			if len(out) == 0 || i-out[len(out)-1] > win {
+				out = append(out, i)
+			}
+		}
+	}
+	return out
+}
+
+func fullThrottleResume(d analysis.Lap, from, to float64) float64 {
+	// first distance where throttle exceeds 0.98 and holds >0.9 for the next ~40m
+	for i := 0; i < len(d.Dist); i++ {
+		if d.Dist[i] < from || d.Dist[i] > to {
+			continue
+		}
+		if d.Thr[i] > 0.98 {
+			ok := true
+			for j := i; j < len(d.Dist) && d.Dist[j] < d.Dist[i]+40; j++ {
+				if d.Thr[j] < 0.9 {
+					ok = false
+					break
+				}
+			}
+			if ok {
+				return d.Dist[i]
+			}
+		}
+	}
+	return to
+}
+
+func gridAround(center, span float64, n int) []float64 {
+	out := make([]float64, n)
+	for i := 0; i < n; i++ {
+		out[i] = center - span + 2*span*float64(i)/float64(n-1)
+	}
+	return out
+}

--- a/telemetry/analysis/analysis.go
+++ b/telemetry/analysis/analysis.go
@@ -1,0 +1,241 @@
+// Package analysis turns decoded .ibt telemetry (telemetry/ibt) into
+// track-agnostic driving metrics: per-lap channel extraction, resampling onto a
+// distance grid, a data-driven flying-lap filter, and speed-minima corner
+// detection.
+//
+// Everything here is pure (data in, data out, no printing) so it can back both
+// the local coaching CLI and any future server-side analysis.
+package analysis
+
+import (
+	"math"
+	"sort"
+
+	"github.com/jonsabados/saturdaysspinout/telemetry/ibt"
+)
+
+// Lap holds one lap's channels at native sample rate, with distance monotonic
+// from the start/finish line.
+type Lap struct {
+	Dist  []float64 // meters from S/F (monotonic)
+	TElap []float64 // elapsed seconds from lap start
+	Speed []float64 // m/s
+	Thr   []float64
+	Brk   []float64
+	Steer []float64 // SteeringWheelAngle, radians (×180/π for degrees)
+	Gear  []float64 // discrete — sample with Nearest, never Interp (interpolation yields 1.3 mid-shift)
+	RPM   []float64
+	LatA  []float64
+	Lat   []float64
+	Lon   []float64
+}
+
+// ExtractLap pulls a single lap's channels from a decoded file, keeping distance
+// monotonic (dropping rare backward GPS jitter).
+func ExtractLap(h *ibt.IBT, lap int32) Lap {
+	L := h.Vars["Lap"]
+	st := h.Vars["SessionTime"]
+	ld := h.Vars["LapDist"]
+	sp := h.Vars["Speed"]
+	th := h.Vars["Throttle"]
+	br := h.Vars["Brake"]
+	sw := h.Vars["SteeringWheelAngle"]
+	gr := h.Vars["Gear"]
+	rp := h.Vars["RPM"]
+	la := h.Vars["LatAccel"]
+	latV := h.Vars["Lat"]
+	lonV := h.Vars["Lon"]
+	var d Lap
+	t0 := 0.0
+	started := false
+	prevDist := -1.0
+	for i := 0; i < h.NumSamples; i++ {
+		if h.Int(L, i) != lap {
+			continue
+		}
+		if !started {
+			t0 = h.Float(st, i)
+			started = true
+		}
+		dist := h.Float(ld, i)
+		if dist < prevDist-1 {
+			continue
+		}
+		prevDist = dist
+		d.Dist = append(d.Dist, dist)
+		d.TElap = append(d.TElap, h.Float(st, i)-t0)
+		d.Speed = append(d.Speed, h.Float(sp, i))
+		d.Thr = append(d.Thr, h.Float(th, i))
+		d.Brk = append(d.Brk, h.Float(br, i))
+		d.Steer = append(d.Steer, h.Float(sw, i))
+		d.Gear = append(d.Gear, h.Float(gr, i))
+		d.RPM = append(d.RPM, h.Float(rp, i))
+		d.LatA = append(d.LatA, h.Float(la, i))
+		d.Lat = append(d.Lat, h.Float(latV, i))
+		d.Lon = append(d.Lon, h.Float(lonV, i))
+	}
+	return d
+}
+
+// Interp linearly interpolates y at x given monotonic-increasing xs.
+func Interp(xs, ys []float64, x float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	if x <= xs[0] {
+		return ys[0]
+	}
+	if x >= xs[len(xs)-1] {
+		return ys[len(ys)-1]
+	}
+	lo, hi := 0, len(xs)-1
+	for hi-lo > 1 {
+		mid := (lo + hi) / 2
+		if xs[mid] <= x {
+			lo = mid
+		} else {
+			hi = mid
+		}
+	}
+	f := (x - xs[lo]) / (xs[hi] - xs[lo])
+	return ys[lo] + f*(ys[hi]-ys[lo])
+}
+
+// Nearest samples ys at the xs closest to x — for discrete channels (gear)
+// that must not be linearly interpolated. xs must be monotonic-increasing.
+func Nearest(xs, ys []float64, x float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	if x <= xs[0] {
+		return ys[0]
+	}
+	if x >= xs[len(xs)-1] {
+		return ys[len(ys)-1]
+	}
+	lo, hi := 0, len(xs)-1
+	for hi-lo > 1 {
+		mid := (lo + hi) / 2
+		if xs[mid] <= x {
+			lo = mid
+		} else {
+			hi = mid
+		}
+	}
+	if x-xs[lo] <= xs[hi]-x {
+		return ys[lo]
+	}
+	return ys[hi]
+}
+
+// Smooth returns a centered moving average with half-window w.
+func Smooth(y []float64, w int) []float64 {
+	out := make([]float64, len(y))
+	for i := range y {
+		s, n := 0.0, 0
+		for k := -w; k <= w; k++ {
+			j := i + k
+			if j >= 0 && j < len(y) {
+				s += y[j]
+				n++
+			}
+		}
+		out[i] = s / float64(n)
+	}
+	return out
+}
+
+// LapTime is one completed lap and its duration in seconds.
+type LapTime struct {
+	Num int32
+	Dur float64
+}
+
+// LapTimes returns every completed lap (start/finish to start/finish) with its
+// duration, derived from Lap-channel transitions. The final incomplete lap has
+// no closing transition and is not included.
+func LapTimes(h *ibt.IBT) []LapTime {
+	lapV := h.Vars["Lap"]
+	stV := h.Vars["SessionTime"]
+	var out []LapTime
+	cur := h.Int(lapV, 0)
+	start := h.Float(stV, 0)
+	for i := 1; i < h.NumSamples; i++ {
+		l := h.Int(lapV, i)
+		if l != cur {
+			t := h.Float(stV, i)
+			out = append(out, LapTime{cur, t - start})
+			cur = l
+			start = t
+		}
+	}
+	return out
+}
+
+// FlyingOpts parameterizes the data-driven flying-lap filter.
+type FlyingOpts struct {
+	MinFrac    float64 // lower bound as a fraction of the best clean lap
+	MaxFrac    float64 // upper bound as a fraction of the best clean lap
+	FloorSec   float64 // absolute minimum plausible lap time (excludes partials/pit)
+	MedianFrac float64 // minimum plausible lap time as a fraction of the median lap
+}
+
+// DefaultFlyingOpts keeps laps within [0.95x, 1.20x] of the best clean lap,
+// which adapts to any car/track (Suzuka ~1:37 and Mugello ~1:27 alike) while
+// excluding out/in and obviously broken laps.
+func DefaultFlyingOpts() FlyingOpts {
+	return FlyingOpts{MinFrac: 0.95, MaxFrac: 1.20, FloorSec: 20, MedianFrac: 0.5}
+}
+
+// FlyingLaps returns representative racing laps using DefaultFlyingOpts.
+func FlyingLaps(h *ibt.IBT) []LapTime {
+	return filterFlying(LapTimes(h), DefaultFlyingOpts())
+}
+
+// partialFloor is the shortest duration filterFlying will accept as a complete
+// lap. A fixed floor cannot do this alone: telemetry that starts mid-lap yields
+// a partial "lap" of arbitrary length, and one longer than the constant floor
+// would otherwise become the best lap and collapse the window onto itself. The
+// median lap is a robust anchor because real laps cluster tightly while
+// partials and pit laps sit far out on either side. Degenerate stints (mostly
+// partials, only a lap or two complete) can still pull the median down; those
+// surface as an empty or tiny result rather than a plausible-looking wrong one.
+func partialFloor(laps []LapTime, opt FlyingOpts) float64 {
+	floor := opt.FloorSec
+	durs := make([]float64, len(laps))
+	for i, l := range laps {
+		durs[i] = l.Dur
+	}
+	sort.Float64s(durs)
+	if n := len(durs); n > 0 {
+		med := durs[n/2]
+		if n%2 == 0 {
+			med = (durs[n/2-1] + durs[n/2]) / 2
+		}
+		if byMedian := med * opt.MedianFrac; byMedian > floor {
+			floor = byMedian
+		}
+	}
+	return floor
+}
+
+// filterFlying selects flying laps relative to the best lap above the floor.
+func filterFlying(laps []LapTime, opt FlyingOpts) []LapTime {
+	floor := partialFloor(laps, opt)
+	best := math.Inf(1)
+	for _, l := range laps {
+		if l.Dur >= floor && l.Dur < best {
+			best = l.Dur
+		}
+	}
+	if math.IsInf(best, 1) {
+		return nil
+	}
+	var out []LapTime
+	for _, l := range laps {
+		if l.Dur >= best*opt.MinFrac && l.Dur <= best*opt.MaxFrac {
+			out = append(out, l)
+		}
+	}
+	return out
+}

--- a/telemetry/analysis/analysis_test.go
+++ b/telemetry/analysis/analysis_test.go
@@ -1,0 +1,229 @@
+package analysis
+
+import (
+	"math"
+	"testing"
+)
+
+func TestInterp(t *testing.T) {
+	xs := []float64{0, 10, 20}
+	ys := []float64{0, 100, 300}
+	cases := []struct {
+		x, want float64
+	}{
+		{-5, 0},   // clamp low
+		{0, 0},    // exact start
+		{5, 50},   // mid first segment
+		{10, 100}, // knot
+		{15, 200}, // mid second segment
+		{20, 300}, // exact end
+		{99, 300}, // clamp high
+	}
+	for _, c := range cases {
+		got := Interp(xs, ys, c.x)
+		if math.Abs(got-c.want) > 1e-9 {
+			t.Errorf("Interp(%.0f) = %.3f, want %.3f", c.x, got, c.want)
+		}
+	}
+	if got := Interp(nil, nil, 5); got != 0 {
+		t.Errorf("Interp(empty) = %.3f, want 0", got)
+	}
+}
+
+func TestNearest(t *testing.T) {
+	// discrete gear channel: must snap, never blend (no 1.3 between 1 and 2).
+	xs := []float64{0, 10, 20}
+	ys := []float64{1, 2, 3}
+	cases := []struct {
+		x, want float64
+	}{
+		{-5, 1}, // clamp low
+		{2, 1},  // closer to xs[0]
+		{4, 1},  // still closer to xs[0]
+		{6, 2},  // closer to xs[1]
+		{10, 2}, // exact
+		{16, 3}, // closer to xs[2]
+		{99, 3}, // clamp high
+	}
+	for _, c := range cases {
+		if got := Nearest(xs, ys, c.x); got != c.want {
+			t.Errorf("Nearest(%.0f) = %.1f, want %.1f (must not interpolate)", c.x, got, c.want)
+		}
+	}
+}
+
+func TestFilterFlying(t *testing.T) {
+	// Mugello-like stint: one out-lap, several ~87s flyers, one messy lap, one pit lap.
+	laps := []LapTime{
+		{Num: 0, Dur: 109.8}, // out-lap: excluded (too slow)
+		{Num: 1, Dur: 87.5},
+		{Num: 2, Dur: 87.6},
+		{Num: 3, Dur: 89.2}, // messy but within tolerance: kept
+		{Num: 8, Dur: 86.7}, // best
+		{Num: 20, Dur: 150}, // pit lap: excluded
+	}
+	out := filterFlying(laps, DefaultFlyingOpts())
+	wantNums := map[int32]bool{1: true, 2: true, 3: true, 8: true}
+	if len(out) != len(wantNums) {
+		t.Fatalf("got %d flying laps, want %d (%v)", len(out), len(wantNums), out)
+	}
+	for _, l := range out {
+		if !wantNums[l.Num] {
+			t.Errorf("lap %d should not be flying (dur %.1f)", l.Num, l.Dur)
+		}
+	}
+}
+
+func TestFilterFlyingIgnoresPartialsWhenPickingBest(t *testing.T) {
+	// A 5s partial must not be treated as the "best" lap and drag the window down.
+	laps := []LapTime{{Num: 0, Dur: 5}, {Num: 1, Dur: 90}, {Num: 2, Dur: 91}}
+	out := filterFlying(laps, DefaultFlyingOpts())
+	if len(out) != 2 {
+		t.Fatalf("got %d flying laps, want 2 (%v)", len(out), out)
+	}
+}
+
+func TestFilterFlyingIgnoresLongPartialOutLap(t *testing.T) {
+	// Regression: telemetry that starts mid-lap produces a partial far longer
+	// than a fixed seconds floor. Mugello 2026-08-14 14-59-37 opened with a
+	// 21.817s partial; it cleared the 20s floor, became the "best" lap, and the
+	// +/-20% window then discarded every real ~87s lap in the session.
+	laps := []LapTime{
+		{Num: 0, Dur: 21.817}, // partial: telemetry started mid-lap
+		{Num: 1, Dur: 92.950},
+		{Num: 2, Dur: 88.400},
+		{Num: 3, Dur: 87.317},
+		{Num: 4, Dur: 86.900}, // best
+		{Num: 5, Dur: 87.550},
+		{Num: 6, Dur: 87.317},
+		{Num: 7, Dur: 87.067},
+	}
+	out := filterFlying(laps, DefaultFlyingOpts())
+	if len(out) != 7 {
+		t.Fatalf("got %d flying laps, want 7 (%v)", len(out), out)
+	}
+	for _, l := range out {
+		if l.Num == 0 {
+			t.Errorf("partial out-lap (%.3fs) must not be a flying lap", l.Dur)
+		}
+	}
+}
+
+func TestFilterFlyingIgnoresVeryLongPartialOutLap(t *testing.T) {
+	// Same defect, larger partial: Mugello 2026-08-14 14-11-26 opened with a
+	// 34.217s partial ahead of a 19-lap time-trial stint.
+	laps := []LapTime{{Num: 0, Dur: 34.217}}
+	for i := 1; i <= 19; i++ {
+		laps = append(laps, LapTime{Num: int32(i), Dur: 85.350 + float64(i%4)})
+	}
+	out := filterFlying(laps, DefaultFlyingOpts())
+	if len(out) != 19 {
+		t.Fatalf("got %d flying laps, want 19 (%v)", len(out), out)
+	}
+	for _, l := range out {
+		if l.Num == 0 {
+			t.Errorf("partial out-lap (%.3fs) must not be a flying lap", l.Dur)
+		}
+	}
+}
+
+func TestPartialFloorScalesWithLapLength(t *testing.T) {
+	// The floor must track the car/track, not a constant: a 21.8s partial is
+	// bogus at Mugello (~87s laps) but a plausible lap somewhere much shorter.
+	mugello := []LapTime{{Dur: 21.817}, {Dur: 87.3}, {Dur: 86.9}, {Dur: 87.5}}
+	if got := partialFloor(mugello, DefaultFlyingOpts()); got <= 21.817 {
+		t.Errorf("Mugello floor = %.3f, want > 21.817 so the partial is rejected", got)
+	}
+	kart := []LapTime{{Dur: 21.817}, {Dur: 22.4}, {Dur: 22.1}, {Dur: 21.9}}
+	if got := partialFloor(kart, DefaultFlyingOpts()); got > 21.817 {
+		t.Errorf("short-track floor = %.3f, want <= 21.817 so real laps survive", got)
+	}
+}
+
+type dip struct{ center, depth, sigma float64 }
+
+// makeDips builds a uniform-grid speed trace (km/h) with Gaussian speed dips,
+// standing in for corners on an otherwise flat-out straight.
+func makeDips(n int, trackLen, base float64, dips []dip) (dist, spd []float64) {
+	dist = make([]float64, n)
+	spd = make([]float64, n)
+	for i := 0; i < n; i++ {
+		x := float64(i) / float64(n-1) * trackLen
+		v := base
+		for _, d := range dips {
+			v -= d.depth * math.Exp(-((x-d.center)*(x-d.center))/(2*d.sigma*d.sigma))
+		}
+		dist[i] = x
+		spd[i] = v
+	}
+	return dist, spd
+}
+
+func nearestCorner(cs []Corner, at float64) (Corner, float64) {
+	best := Corner{}
+	bestD := math.Inf(1)
+	for _, c := range cs {
+		if d := math.Abs(c.ApexDist - at); d < bestD {
+			bestD = d
+			best = c
+		}
+	}
+	return best, bestD
+}
+
+func TestDetectCorners(t *testing.T) {
+	// three real corners plus a shallow straight-line kink that must be ignored.
+	dist, spd := makeDips(600, 6000, 285, []dip{
+		{center: 1000, depth: 185, sigma: 60}, // ~100 km/h
+		{center: 3000, depth: 125, sigma: 60}, // ~160 km/h
+		{center: 4500, depth: 6, sigma: 50},   // shallow: reject
+		{center: 5200, depth: 205, sigma: 55}, // ~80 km/h
+	})
+	cs := DetectCorners(dist, spd, DefaultCornerOpts())
+	if len(cs) != 3 {
+		t.Fatalf("detected %d corners, want 3: %+v", len(cs), cs)
+	}
+	for _, at := range []float64{1000, 3000, 5200} {
+		if _, d := nearestCorner(cs, at); d > 60 {
+			t.Errorf("no corner within 60m of %.0fm (nearest %.0fm off)", at, d)
+		}
+	}
+	if _, d := nearestCorner(cs, 4500); d < 200 {
+		t.Errorf("shallow kink at 4500m was detected as a corner (%.0fm away)", d)
+	}
+}
+
+func TestDetectCornersProminenceThreshold(t *testing.T) {
+	opt := CornerOpts{ProminenceKmh: 12, MinSpacingM: 150, MaxApexSpeedKmh: 300, SmoothWin: 4}
+
+	_, shallow := makeDips(400, 4000, 240, []dip{{center: 2000, depth: 6, sigma: 60}})
+	distS, _ := makeDips(400, 4000, 240, nil)
+	if cs := DetectCorners(distS, shallow, opt); len(cs) != 0 {
+		t.Errorf("6 km/h dip (below prominence) detected as %d corners: %+v", len(cs), cs)
+	}
+
+	dist, deep := makeDips(400, 4000, 240, []dip{{center: 2000, depth: 20, sigma: 60}})
+	if cs := DetectCorners(dist, deep, opt); len(cs) != 1 {
+		t.Errorf("20 km/h dip (above prominence) detected as %d corners, want 1", len(cs))
+	}
+}
+
+func TestDetectCornersMergesBySpacing(t *testing.T) {
+	// two minima 110m apart (< MinSpacing) must collapse to the slower one.
+	opt := DefaultCornerOpts()
+	opt.SmoothWin = 1 // keep the two sharp minima distinct
+	dist, spd := makeDips(600, 6000, 285, []dip{
+		{center: 2000, depth: 110, sigma: 25}, // ~175 km/h
+		{center: 2110, depth: 150, sigma: 25}, // ~135 km/h (slower)
+	})
+	cs := DetectCorners(dist, spd, opt)
+	if len(cs) != 1 {
+		t.Fatalf("detected %d corners, want 1 (merged): %+v", len(cs), cs)
+	}
+	if cs[0].ApexDist < 2050 || cs[0].ApexDist > 2170 {
+		t.Errorf("merged corner apex %.0fm, want the slower one near 2110m", cs[0].ApexDist)
+	}
+	if cs[0].ApexSpeedKmh > 160 {
+		t.Errorf("merged corner kept the faster apex (%.1f km/h); want the slower ~135", cs[0].ApexSpeedKmh)
+	}
+}

--- a/telemetry/analysis/corners.go
+++ b/telemetry/analysis/corners.go
@@ -1,0 +1,122 @@
+package analysis
+
+import (
+	"math"
+	"sort"
+)
+
+// Resample returns a uniform distance grid over the lap and the speed (km/h) at
+// each grid point, interpolated from native samples.
+func Resample(lap Lap, n int) (dist, speedKmh []float64) {
+	dist = make([]float64, n)
+	speedKmh = make([]float64, n)
+	if len(lap.Dist) == 0 {
+		return dist, speedKmh
+	}
+	trackLen := lap.Dist[len(lap.Dist)-1]
+	for i := 0; i < n; i++ {
+		x := float64(i) / float64(n-1) * trackLen
+		dist[i] = x
+		speedKmh[i] = Interp(lap.Dist, lap.Speed, x) * 3.6
+	}
+	return dist, speedKmh
+}
+
+// Corner is a detected corner: the apex distance from S/F, the minimum speed
+// there, and an optional human name (populated from a per-track overlay).
+type Corner struct {
+	ApexDist     float64
+	ApexSpeedKmh float64
+	Name         string
+}
+
+// CornerOpts parameterizes speed-minima corner detection.
+type CornerOpts struct {
+	ProminenceKmh   float64 // required speed rise on both sides of a minimum (rejects wiggles)
+	MinSpacingM     float64 // minima closer than this collapse to the slower one
+	MaxApexSpeedKmh float64 // ignore minima faster than this (flat-out kinks)
+	SmoothWin       int     // half-window for smoothing the speed trace
+}
+
+// DefaultCornerOpts is tuned for open-wheel/GT speed traces: a corner must shed
+// at least 12 km/h relative to the straights bracketing it, corners within 150 m
+// merge, and anything above 255 km/h is treated as a straight-line kink.
+func DefaultCornerOpts() CornerOpts {
+	return CornerOpts{ProminenceKmh: 12, MinSpacingM: 150, MaxApexSpeedKmh: 255, SmoothWin: 8}
+}
+
+// DetectCorners finds corner apexes as prominent local minima on a resampled,
+// smoothed speed trace. dist and speedKmh must be the uniform grid from Resample
+// (equal length). Prominence is the topographic key-col measure: from a minimum,
+// walk outward until the trace drops below it (entering another basin); the
+// highest point reached on each side, minus the minimum, bounds the prominence.
+func DetectCorners(dist, speedKmh []float64, opt CornerOpts) []Corner {
+	n := len(speedKmh)
+	if n < 5 || len(dist) != n {
+		return nil
+	}
+	sm := Smooth(speedKmh, opt.SmoothWin)
+
+	const wp = 3 // local-minimum flatness window (grid points)
+	type cand struct {
+		i     int
+		speed float64
+	}
+	var cands []cand
+	for i := wp; i < n-wp; i++ {
+		if sm[i] > opt.MaxApexSpeedKmh {
+			continue
+		}
+		isMin := true
+		for k := i - wp; k <= i+wp; k++ {
+			if sm[k] < sm[i] {
+				isMin = false
+				break
+			}
+		}
+		if !isMin {
+			continue
+		}
+		leftMax := sm[i]
+		for k := i - 1; k >= 0; k-- {
+			if sm[k] < sm[i]-0.1 {
+				break // dropped into a deeper basin: this is the col
+			}
+			if sm[k] > leftMax {
+				leftMax = sm[k]
+			}
+		}
+		rightMax := sm[i]
+		for k := i + 1; k < n; k++ {
+			if sm[k] < sm[i]-0.1 {
+				break
+			}
+			if sm[k] > rightMax {
+				rightMax = sm[k]
+			}
+		}
+		prom := math.Min(leftMax-sm[i], rightMax-sm[i])
+		if prom >= opt.ProminenceKmh {
+			cands = append(cands, cand{i, sm[i]})
+		}
+	}
+
+	// Collapse minima closer than MinSpacingM, keeping the slower apex.
+	sort.Slice(cands, func(a, b int) bool { return cands[a].i < cands[b].i })
+	var kept []cand
+	for _, c := range cands {
+		if len(kept) > 0 && dist[c.i]-dist[kept[len(kept)-1].i] < opt.MinSpacingM {
+			if c.speed < kept[len(kept)-1].speed {
+				kept[len(kept)-1] = c
+			}
+			continue
+		}
+		kept = append(kept, c)
+	}
+
+	corners := make([]Corner, len(kept))
+	for i, c := range kept {
+		corners[i] = Corner{ApexDist: dist[c.i], ApexSpeedKmh: c.speed}
+	}
+	return corners
+}

--- a/telemetry/analysis/overlays.go
+++ b/telemetry/analysis/overlays.go
@@ -1,0 +1,7 @@
+package analysis
+
+// Per-track corner overlays — canonical, named corner lists that stay stable
+// across sessions regardless of how a given lap was driven (a tire-saving lift
+// leaves no speed dip, so pure detection is lap-dependent) — are intentionally
+// deferred: the tool currently relies on auto-detected corners. When overlays
+// land, they live here.

--- a/telemetry/analysis/summary.go
+++ b/telemetry/analysis/summary.go
@@ -1,0 +1,206 @@
+package analysis
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"strings"
+
+	"github.com/jonsabados/saturdaysspinout/telemetry/ibt"
+)
+
+// CornerConsistency captures how repeatable a corner is across a session's
+// flying laps: apex minimum-speed spread and braking-point spread.
+type CornerConsistency struct {
+	Name         string  `json:"name"`
+	ApexDist     float64 `json:"apex_m"`
+	MinSpeedMean float64 `json:"min_kmh_mean"`
+	MinSpeedStd  float64 `json:"min_kmh_std"`
+	MinSpeedLo   float64 `json:"min_kmh_lo"`
+	MinSpeedHi   float64 `json:"min_kmh_hi"`
+	// nil when there's no braking here or the onset fell outside the search
+	// window — distinct from a genuine, repeatable 0.0m spread.
+	BrakePointStd *float64 `json:"brake_pt_std_m,omitempty"`
+}
+
+// SessionSummary is the trendable digest of one telemetry session: identity,
+// lap-time distribution over flying laps, and per-corner consistency. It is the
+// unit the journal appends and the future ingestion feature would produce.
+type SessionSummary struct {
+	Track  string `json:"track"`
+	Car    string `json:"car"`
+	Driver string `json:"driver"`
+	// Conditions — needed so trends don't line up non-comparable laps (an 8L
+	// quali lap next to a 55L race lap). Kept as raw strings incl. units.
+	SessionType string              `json:"session_type,omitempty"`
+	Fuel        string              `json:"fuel,omitempty"`
+	BrakeBias   string              `json:"brake_bias,omitempty"`
+	TrackTempC  string              `json:"track_temp_c,omitempty"`
+	AirTempC    string              `json:"air_temp_c,omitempty"`
+	FlyingLaps  int                 `json:"flying_laps"`
+	BestLapSec  float64             `json:"best_lap_s"`
+	MeanLapSec  float64             `json:"mean_lap_s"`
+	StdLapSec   float64             `json:"std_lap_s"`
+	TrackLen    float64             `json:"track_len_m"`
+	Corners     []CornerConsistency `json:"corners"`
+}
+
+// SummarizeSession computes a SessionSummary: flying laps, lap-time stats, and
+// per-corner min-speed / braking-point consistency using auto-detected corners
+// from the fastest flying lap.
+func SummarizeSession(h *ibt.IBT, opt CornerOpts) SessionSummary {
+	var s SessionSummary
+	yaml := h.SessionYAML()
+	s.Track = sessionField(yaml, "TrackName")
+	s.Car = sessionField(yaml, "CarScreenName")
+	s.Driver = sessionField(yaml, "UserName")
+	s.SessionType = sessionField(yaml, "SessionType")
+	s.Fuel = sessionField(yaml, "FuelLevel")
+	s.BrakeBias = sessionField(yaml, "BrakePressureBias")
+	s.TrackTempC = sessionField(yaml, "TrackSurfaceTemp")
+	s.AirTempC = sessionField(yaml, "TrackAirTemp")
+
+	laps := FlyingLaps(h)
+	s.FlyingLaps = len(laps)
+	if len(laps) == 0 {
+		return s
+	}
+	best := laps[0]
+	var durs []float64
+	for _, l := range laps {
+		durs = append(durs, l.Dur)
+		if l.Dur < best.Dur {
+			best = l
+		}
+	}
+	s.BestLapSec = best.Dur
+	s.MeanLapSec = mean(durs)
+	s.StdLapSec = std(durs)
+
+	refLap := ExtractLap(h, best.Num)
+	s.TrackLen = refLap.Dist[len(refLap.Dist)-1]
+	const N = 800
+	grid := make([]float64, N)
+	for i := range grid {
+		grid[i] = float64(i) / float64(N-1) * s.TrackLen
+	}
+	rDist, rSpd := Resample(refLap, N)
+	corners := DetectCorners(rDist, rSpd, opt)
+	for i := range corners {
+		if corners[i].Name == "" {
+			corners[i].Name = fmt.Sprintf("C%d", i+1)
+		}
+	}
+
+	// resample every flying lap onto the grid once
+	type lapGrid struct{ spd, brk []float64 }
+	var grids []lapGrid
+	for _, li := range laps {
+		d := ExtractLap(h, li.Num)
+		if len(d.Dist) < 10 {
+			continue
+		}
+		sp := make([]float64, N)
+		br := make([]float64, N)
+		for i, x := range grid {
+			sp[i] = Interp(d.Dist, d.Speed, x) * 3.6
+			br[i] = Interp(d.Dist, d.Brk, x)
+		}
+		grids = append(grids, lapGrid{sp, br})
+	}
+
+	win := int(60.0 / s.TrackLen * float64(N))
+	brakeWin := int(160.0 / s.TrackLen * float64(N))
+	for _, c := range corners {
+		gi := int(c.ApexDist / s.TrackLen * float64(N-1))
+		var mins, bpts []float64
+		for _, g := range grids {
+			mn := math.Inf(1)
+			for k := gi - win; k <= gi+win; k++ {
+				if k >= 0 && k < N && g.spd[k] < mn {
+					mn = g.spd[k]
+				}
+			}
+			mins = append(mins, mn)
+			// only a valid braking point if braking happened and the onset was
+			// found inside the window (didn't clamp at the edge) — else a false 0.0
+			kk := gi
+			for kk > gi-brakeWin && kk > 0 && g.brk[kk] < 0.08 {
+				kk--
+			}
+			braked := kk > gi-brakeWin && kk > 0 && g.brk[kk] >= 0.08
+			for kk > gi-brakeWin && kk > 0 && g.brk[kk] >= 0.08 {
+				kk--
+			}
+			if braked && kk > gi-brakeWin && kk > 0 {
+				bpts = append(bpts, grid[kk+1])
+			}
+		}
+		lo, hi := minmax(mins)
+		cc := CornerConsistency{
+			Name:         c.Name,
+			ApexDist:     c.ApexDist,
+			MinSpeedMean: mean(mins),
+			MinSpeedStd:  std(mins),
+			MinSpeedLo:   lo,
+			MinSpeedHi:   hi,
+		}
+		if len(bpts) >= 2 {
+			v := std(bpts)
+			cc.BrakePointStd = &v
+		}
+		s.Corners = append(s.Corners, cc)
+	}
+	return s
+}
+
+// TrackName returns the session's TrackName field from the embedded YAML.
+func TrackName(h *ibt.IBT) string {
+	return sessionField(h.SessionYAML(), "TrackName")
+}
+
+func sessionField(yaml, key string) string {
+	if m := regexp.MustCompile(key + `: ?(.*)`).FindStringSubmatch(yaml); m != nil {
+		return strings.TrimSpace(m[1])
+	}
+	return ""
+}
+
+func mean(v []float64) float64 {
+	if len(v) == 0 {
+		return 0
+	}
+	s := 0.0
+	for _, x := range v {
+		s += x
+	}
+	return s / float64(len(v))
+}
+
+func std(v []float64) float64 {
+	if len(v) < 2 {
+		return 0
+	}
+	m := mean(v)
+	s := 0.0
+	for _, x := range v {
+		s += (x - m) * (x - m)
+	}
+	return math.Sqrt(s / float64(len(v)-1))
+}
+
+func minmax(v []float64) (float64, float64) {
+	if len(v) == 0 {
+		return 0, 0
+	}
+	lo, hi := v[0], v[0]
+	for _, x := range v {
+		if x < lo {
+			lo = x
+		}
+		if x > hi {
+			hi = x
+		}
+	}
+	return lo, hi
+}

--- a/telemetry/ibt/ibt.go
+++ b/telemetry/ibt/ibt.go
@@ -1,0 +1,190 @@
+// Package ibt decodes iRacing .ibt telemetry files (the binary irsdk on-disk
+// format): a fixed header, an array of variable headers, a session-info YAML
+// blob, and fixed-length sample buffers recorded at the session tick rate.
+//
+// It is intentionally dependency-free and read-only so it can be shared between
+// the local coaching CLI (cmd/ibt) and any future server-side ingestion.
+package ibt
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"os"
+)
+
+// irsdk var types
+const (
+	irChar    = 0
+	irBool    = 1
+	irInt     = 2
+	irBitfeld = 3
+	irFloat   = 4
+	irDouble  = 5
+)
+
+var typeSize = map[int32]int{irChar: 1, irBool: 1, irInt: 4, irBitfeld: 4, irFloat: 4, irDouble: 8}
+
+// VarHeader describes one telemetry channel (its type, byte offset within a
+// sample buffer, element count, and metadata).
+type VarHeader struct {
+	Type   int32
+	Offset int32
+	Count  int32
+	Name   string
+	Desc   string
+	Unit   string
+}
+
+// IBT is a parsed .ibt file held entirely in memory, with the variable headers
+// indexed by name and the sample count precomputed.
+type IBT struct {
+	data       []byte
+	Ver        int32
+	TickRate   int32
+	SessLen    int32
+	SessOff    int32
+	NumVars    int32
+	VarOff     int32
+	NumBuf     int32
+	BufLen     int32
+	DataOffset int32
+	Vars       map[string]VarHeader
+	VarList    []VarHeader
+	NumSamples int
+}
+
+func cstr(b []byte) string {
+	for i, c := range b {
+		if c == 0 {
+			return string(b[:i])
+		}
+	}
+	return string(b)
+}
+
+// Open reads and parses an .ibt file from disk.
+func Open(path string) (*IBT, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	// The fixed header is 112 bytes; we read offsets up through byte 55. Bail
+	// with an error rather than slicing out of bounds on a short/corrupt file.
+	const headerSize = 112
+	if len(data) < headerSize {
+		return nil, fmt.Errorf("ibt: file too small: %d bytes (need >= %d for the header)", len(data), headerSize)
+	}
+	le := binary.LittleEndian
+	h := &IBT{data: data}
+	h.Ver = int32(le.Uint32(data[0:]))
+	h.TickRate = int32(le.Uint32(data[8:]))
+	h.SessLen = int32(le.Uint32(data[16:]))
+	h.SessOff = int32(le.Uint32(data[20:]))
+	h.NumVars = int32(le.Uint32(data[24:]))
+	h.VarOff = int32(le.Uint32(data[28:]))
+	h.NumBuf = int32(le.Uint32(data[32:]))
+	h.BufLen = int32(le.Uint32(data[36:]))
+	// varBuf[0] starts at offset 48: {tickCount int, bufOffset int, pad[2]}
+	h.DataOffset = int32(le.Uint32(data[52:]))
+
+	h.Vars = make(map[string]VarHeader)
+	for i := int32(0); i < h.NumVars; i++ {
+		base := h.VarOff + i*144
+		if int(base)+144 > len(data) {
+			break
+		}
+		v := VarHeader{
+			Type:   int32(le.Uint32(data[base:])),
+			Offset: int32(le.Uint32(data[base+4:])),
+			Count:  int32(le.Uint32(data[base+8:])),
+			Name:   cstr(data[base+16 : base+48]),
+			Desc:   cstr(data[base+48 : base+112]),
+			Unit:   cstr(data[base+112 : base+144]),
+		}
+		h.Vars[v.Name] = v
+		h.VarList = append(h.VarList, v)
+	}
+	if h.BufLen > 0 && int(h.DataOffset) >= 0 && int(h.DataOffset) <= len(data) {
+		h.NumSamples = (len(data) - int(h.DataOffset)) / int(h.BufLen)
+	}
+	return h, nil
+}
+
+// SessionYAML returns the session-info YAML blob embedded in the file.
+func (h *IBT) SessionYAML() string {
+	if h.SessOff < 0 || int(h.SessOff) > len(h.data) {
+		return ""
+	}
+	end := h.SessOff + h.SessLen
+	if end < h.SessOff || int(end) > len(h.data) {
+		end = int32(len(h.data))
+	}
+	return cstr(h.data[h.SessOff:end])
+}
+
+// sample buffer for sample i
+func (h *IBT) row(i int) []byte {
+	start := int(h.DataOffset) + i*int(h.BufLen)
+	return h.data[start : start+int(h.BufLen)]
+}
+
+// Float reads channel v at sample i as a float64, coercing whatever the
+// underlying irsdk type is.
+func (h *IBT) Float(v VarHeader, i int) float64 {
+	row := h.row(i)
+	b := row[v.Offset:]
+	switch v.Type {
+	case irFloat:
+		return float64(math.Float32frombits(binary.LittleEndian.Uint32(b)))
+	case irDouble:
+		return math.Float64frombits(binary.LittleEndian.Uint64(b))
+	case irInt, irBitfeld:
+		return float64(int32(binary.LittleEndian.Uint32(b)))
+	case irBool, irChar:
+		return float64(b[0])
+	}
+	return 0
+}
+
+// Int reads channel v at sample i as an int32.
+func (h *IBT) Int(v VarHeader, i int) int32 {
+	row := h.row(i)
+	b := row[v.Offset:]
+	switch v.Type {
+	case irInt, irBitfeld:
+		return int32(binary.LittleEndian.Uint32(b))
+	case irBool, irChar:
+		return int32(b[0])
+	case irFloat:
+		return int32(math.Float32frombits(binary.LittleEndian.Uint32(b)))
+	case irDouble:
+		return int32(math.Float64frombits(binary.LittleEndian.Uint64(b)))
+	}
+	return 0
+}
+
+// FloatArr reads a channel that may have Count>1 (per-corner data etc.).
+func (h *IBT) FloatArr(v VarHeader, i int) []float64 {
+	out := make([]float64, v.Count)
+	sz := typeSize[v.Type]
+	row := h.row(i)
+	for k := int32(0); k < v.Count; k++ {
+		off := int(v.Offset) + int(k)*sz
+		if off < 0 || off+sz > len(row) { // corrupt Offset/Count: stop rather than slice OOB
+			break
+		}
+		b := row[off:]
+		switch v.Type {
+		case irFloat:
+			out[k] = float64(math.Float32frombits(binary.LittleEndian.Uint32(b)))
+		case irDouble:
+			out[k] = math.Float64frombits(binary.LittleEndian.Uint64(b))
+		case irInt, irBitfeld:
+			out[k] = float64(int32(binary.LittleEndian.Uint32(b)))
+		default:
+			out[k] = float64(b[0])
+		}
+	}
+	return out
+}

--- a/telemetry/ibt/ibt_test.go
+++ b/telemetry/ibt/ibt_test.go
@@ -1,0 +1,79 @@
+package ibt
+
+import (
+	"encoding/binary"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// buildIBT crafts a minimal but structurally valid .ibt: 112-byte header, one
+// float VarHeader ("Speed"), a session-info YAML blob, and a single sample.
+func buildIBT(yaml string, speed float32) []byte {
+	const (
+		varOff  = 112
+		varSize = 144
+		bufLen  = 4
+	)
+	sessOff := varOff + varSize
+	sessLen := len(yaml)
+	dataOff := sessOff + sessLen
+	b := make([]byte, dataOff+bufLen)
+	le := binary.LittleEndian
+	le.PutUint32(b[0:], 2)                // Ver
+	le.PutUint32(b[8:], 60)               // TickRate
+	le.PutUint32(b[16:], uint32(sessLen)) // SessLen
+	le.PutUint32(b[20:], uint32(sessOff)) // SessOff
+	le.PutUint32(b[24:], 1)               // NumVars
+	le.PutUint32(b[28:], uint32(varOff))  // VarOff
+	le.PutUint32(b[32:], 1)               // NumBuf
+	le.PutUint32(b[36:], uint32(bufLen))  // BufLen
+	le.PutUint32(b[52:], uint32(dataOff)) // varBuf[0].bufOffset -> DataOffset
+	le.PutUint32(b[varOff+0:], irFloat)   // Type
+	le.PutUint32(b[varOff+4:], 0)         // Offset within the sample row
+	le.PutUint32(b[varOff+8:], 1)         // Count
+	copy(b[varOff+16:], "Speed")          // Name
+	copy(b[sessOff:], yaml)               // session YAML
+	le.PutUint32(b[dataOff:], math.Float32bits(speed))
+	return b
+}
+
+func TestOpenDecodesHeaderAndChannel(t *testing.T) {
+	yaml := "WeekendInfo:\n TrackName: testtrack\n"
+	path := filepath.Join(t.TempDir(), "test.ibt")
+	if err := os.WriteFile(path, buildIBT(yaml, 42.5), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if h.Ver != 2 || h.TickRate != 60 || h.NumVars != 1 {
+		t.Errorf("header = ver %d tick %d vars %d, want 2/60/1", h.Ver, h.TickRate, h.NumVars)
+	}
+	if h.NumSamples != 1 {
+		t.Errorf("NumSamples = %d, want 1", h.NumSamples)
+	}
+	v, ok := h.Vars["Speed"]
+	if !ok {
+		t.Fatal("Speed channel not decoded")
+	}
+	if got := h.Float(v, 0); math.Abs(got-42.5) > 1e-5 {
+		t.Errorf("Float(Speed,0) = %v, want 42.5", got)
+	}
+	if !strings.Contains(h.SessionYAML(), "TrackName: testtrack") {
+		t.Errorf("SessionYAML missing track name: %q", h.SessionYAML())
+	}
+}
+
+func TestOpenRejectsShortFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "short.ibt")
+	if err := os.WriteFile(path, make([]byte, 10), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Open(path); err == nil {
+		t.Error("Open on a 10-byte file: want error, got nil (would panic slicing the header)")
+	}
+}


### PR DESCRIPTION
Local driving-analysis system (not part of the deployed app): a Go CLI decodes iRacing .ibt telemetry into driving metrics, driven by Claude via the claudecoach skill through a blind-test coaching protocol, with a per-session journal for tracking improvement across sessions.

- telemetry/ibt: dependency-free .ibt binary decoder
- telemetry/analysis: pure, tested analysis core — resampling, data-driven flying-lap filter (median-anchored, rejects partial out-laps), prominence corner detection, session summaries; reusable by a future ingestion feature
- cmd/ibt: summary/consistency/compare/brake/section/journal commands, all track-agnostic (verified on Suzuka and Mugello). compare surfaces a throttle-limited-by-rotation check; summary prints comparability conditions (fuel/temp/session); brakeSTD reports n/a rather than a false 0.0
- .claude/skills/claudecoach: the coaching workflow (blind test, journal, trends)
- claudecoach/journal (gitignored): session summaries for cross-session trends

make ibt builds the CLI; make test covers the new packages.